### PR TITLE
WIP: Refactor representation converter

### DIFF
--- a/Core/src/IfcGeometryConverter/CurveConverter.h
+++ b/Core/src/IfcGeometryConverter/CurveConverter.h
@@ -577,11 +577,7 @@ namespace OpenInfraPlatform {
 									if (first != trim1Vec.end() && (*first) != nullptr) {
 										BLUE_LOG(trace) << "Processing " << circle->getErrorLog() << ": Found trimming begin as IfcCartesianPoint.";
 										try {
-											std::shared_ptr<typename IfcEntityTypesT::IfcCartesianPoint> trim_point1 = (*first)->get<0>().lock();
-
-											BLUE_LOG(trace) << trim_point1->getErrorLog();
-											carve::geom::vector<3> trim_point;
-											placementConverter->convertIfcCartesianPoint(trim_point1, trim_point);
+											carve::geom::vector<3> trim_point = placementConverter->convertIfcCartesianPoint((*first)->get<0>());
 
 											trim_angle1 = getAngleOnCircle(circle_center,
 												circle_radius,
@@ -616,11 +612,7 @@ namespace OpenInfraPlatform {
 										BLUE_LOG(trace) << "Processing " << circle->getErrorLog() << ": Found trimming end as IfcCartesianPoint.";
 
 										try {
-											std::shared_ptr<typename IfcEntityTypesT::IfcCartesianPoint> trim_point2 = (*first)->get<0>().lock();
-
-											BLUE_LOG(trace) << trim_point2->getErrorLog();
-											carve::geom::vector<3> trim_point;
-											placementConverter->convertIfcCartesianPoint(trim_point2, trim_point);
+											carve::geom::vector<3> trim_point = placementConverter->convertIfcCartesianPoint((*first)->get<0>());
 
 											trim_angle2 = getAngleOnCircle(circle_center,
 												circle_radius,
@@ -757,9 +749,7 @@ namespace OpenInfraPlatform {
 						// Part 1: Get information from IfcLine. 
 
 						// Get IfcLine attributes: line point and line direction. 
-						std::shared_ptr<typename IfcEntityTypesT::IfcCartesianPoint> ifc_line_point = line->Pnt.lock();
-						carve::geom::vector<3> line_origin;
-						placementConverter->convertIfcCartesianPoint(ifc_line_point, line_origin);
+						carve::geom::vector<3> line_origin = placementConverter->convertIfcCartesianPoint(line->Pnt);
 
 						std::shared_ptr<typename IfcEntityTypesT::IfcVector> line_vec = line->Dir.lock();
 						if (!line_vec) {
@@ -809,9 +799,7 @@ namespace OpenInfraPlatform {
 							std::shared_ptr<typename IfcEntityTypesT::IfcCartesianPoint> ifc_trim_point;
 							auto first_point = std::find_if(trim1Vec.begin(), trim1Vec.end(), [](auto select_ptr) { return select_ptr->which() == 0; });
 							if (first_point != trim1Vec.end() && *first_point) {
-								ifc_trim_point = (*first_point)->get<0>().lock();
-								carve::geom::vector<3> trim_point;
-								placementConverter->convertIfcCartesianPoint(ifc_trim_point, trim_point);
+								carve::geom::vector<3> trim_point = placementConverter->convertIfcCartesianPoint((*first_point)->get<0>());
 
 								carve::geom::vector<3> closest_point_on_line;
 								GeomUtils::closestPointOnLine(trim_point, line_origin,
@@ -839,9 +827,7 @@ namespace OpenInfraPlatform {
 							auto first_point = std::find_if(trim2Vec.begin(), trim2Vec.end(), [](auto select_ptr) { return select_ptr->which() == 0; });
 
 							if (first_point != trim2Vec.end() && *first_point) {
-								ifc_trim_point = (*first_point)->get<0>().lock();
-								carve::geom::vector<3> trim_point;
-								placementConverter->convertIfcCartesianPoint(ifc_trim_point, trim_point);
+								carve::geom::vector<3> trim_point = placementConverter->convertIfcCartesianPoint((*first_point)->get<0>());
 
 								carve::geom::vector<3> closest_point_on_line;
 								GeomUtils::closestPointOnLine(trim_point, line_origin,
@@ -1148,13 +1134,9 @@ namespace OpenInfraPlatform {
 				{
 					// initialize the return value with enough space
 					std::vector<carve::geom::vector<3>> loop( points.size() );
-					// convert each point individually
-					carve::geom::vector<3> point = carve::geom::VECTOR(0., 0., 0.);
-					for ( auto it = points.begin(); it != points.end(); ++it )
-					{
-						placementConverter->convertIfcCartesianPoint( it->lock(), point);
-						loop.push_back(point);
-					}
+					// convert each point individually and add to the return vector
+					for ( auto& it : points )
+						loop.push_back(placementConverter->convertIfcCartesianPoint(it));
 					// return the loop
 					return loop;
 				} // end convertIfcCartesianPointVector
@@ -1177,8 +1159,7 @@ namespace OpenInfraPlatform {
 					for ( auto& it_cp = ifcPoints.begin(); it_cp != ifcPoints.end(); ++it_cp) {
 						std::shared_ptr<typename IfcEntityTypesT::IfcCartesianPoint> cp = (*it_cp);
 
-						carve::geom::vector<3>  vertex(carve::geom::VECTOR(0.,0.,0.));
-						placementConverter->convertIfcCartesianPoint(*it_cp, vertex);
+						carve::geom::vector<3>  vertex = placementConverter->convertIfcCartesianPoint( *it_cp );
 
 						// skip duplicate vertices
 						if (it_cp != ifcPoints.begin()) {

--- a/Core/src/IfcGeometryConverter/FaceConverter.h
+++ b/Core/src/IfcGeometryConverter/FaceConverter.h
@@ -407,8 +407,7 @@ namespace OpenInfraPlatform {
 				// TODO: What is happening here?
 				void convertIfcFaceList(const std::vector<std::shared_ptr<typename IfcEntityTypesT::IfcFace>>& faces,
 					const carve::math::Matrix& pos,
-					std::shared_ptr<ItemData> item_data,
-					std::stringstream& strs_err)
+					std::shared_ptr<ItemData> item_data)
 				{
 #ifdef _DEBUG
 					BLUE_LOG(trace) << "Converting IfcFaceList. Size:" << faces.size();
@@ -422,7 +421,7 @@ namespace OpenInfraPlatform {
 					for(auto it = faces.cbegin(); it != faces.cend(); ++it) {
 						std::shared_ptr<typename IfcEntityTypesT::IfcFace> face = (*it);
 
-						if(!convertIfcFace(face, pos, polygon, polygonIndices, strs_err)) {
+						if(!convertIfcFace(face, pos, polygon, polygonIndices)) {
 							std::stringstream text;
 							text << "IFC Face convertion failed with faces #" << faces.at(0)->getId() << "-" << faces.at(faces.size() - 1)->getId();
 
@@ -438,8 +437,7 @@ namespace OpenInfraPlatform {
 				bool convertIfcFace(const std::shared_ptr<typename IfcEntityTypesT::IfcFace>& face,
 					const carve::math::Matrix& pos,
 					std::shared_ptr<carve::input::PolyhedronData> polygon,
-					std::map<std::string, uint32_t>& polygonIndices,
-					std::stringstream& strs_err)
+					std::map<std::string, uint32_t>& polygonIndices)
 				{
 					// indicates if convertion has failed
 					bool convertionFailed = false;

--- a/Core/src/IfcGeometryConverter/GeometryInputData.h
+++ b/Core/src/IfcGeometryConverter/GeometryInputData.h
@@ -54,6 +54,15 @@ namespace OpenInfraPlatform {
 				std::vector<std::shared_ptr<carve::input::PolylineSetData>> polylines;
 				std::vector<std::shared_ptr<carve::mesh::MeshSet<3>>>		meshsets;
 				void createMeshSetsFromClosedPolyhedrons();
+
+				void append(const std::shared_ptr<ItemData>& other)
+				{
+					std::copy(other->closed_polyhedrons.begin(),         other->closed_polyhedrons.end(),         std::back_inserter(this->closed_polyhedrons));
+					std::copy(other->open_polyhedrons.begin(),           other->open_polyhedrons.end(),           std::back_inserter(this->open_polyhedrons));
+					std::copy(other->open_or_closed_polyhedrons.begin(), other->open_or_closed_polyhedrons.end(), std::back_inserter(this->open_or_closed_polyhedrons));
+					std::copy(other->polylines.begin(),                  other->polylines.end(),                  std::back_inserter(this->polylines));
+					std::copy(other->meshsets.begin(),                   other->meshsets.end(),                   std::back_inserter(this->meshsets));
+				}
 			};
 
 			/**************************************************************************************/

--- a/Core/src/IfcGeometryConverter/IfcImporter.h
+++ b/Core/src/IfcGeometryConverter/IfcImporter.h
@@ -154,7 +154,7 @@ namespace OpenInfraPlatform
 
 					if(element) {
 						// then collect opening data
-						repConverter->convertOpenings(element, openingDatas, strerr);
+						repConverter->convertOpenings(element, openingDatas);
 					}
 
 					// go through all shapes and convert them to meshsets
@@ -164,7 +164,7 @@ namespace OpenInfraPlatform
 
 						// if product is IfcElement, then subtract openings like windows, doors, etc.
 						if(element) {
-							repConverter->subtractOpenings(element, itemData, openingDatas, strerr);
+							repConverter->subtractOpenings(element, itemData, openingDatas);
 						}
 
 						// convert all open polyhedrons to meshsets

--- a/Core/src/IfcGeometryConverter/IfcImporterImpl.h
+++ b/Core/src/IfcGeometryConverter/IfcImporterImpl.h
@@ -112,7 +112,7 @@ static void OpenInfraPlatform::Core::IfcGeometryConverter::IfcImporterUtil::conv
 		std::shared_ptr<ItemData> itemData(new ItemData());
 		productShape->vec_item_data.push_back(itemData);
 		std::shared_ptr<typename IfcEntityTypesT::IfcGeometricRepresentationItem> axis = std::dynamic_pointer_cast<typename IfcEntityTypesT::IfcGeometricRepresentationItem>(alignment->Axis.lock());
-		repConverter->convertIfcGeometricRepresentationItem(alignment->Axis.as<typename IfcEntityTypesT::IfcGeometricRepresentationItem>(), carve::math::Matrix::IDENT(), itemData, strerr);
+		repConverter->convertIfcGeometricRepresentationItem(alignment->Axis.as<typename IfcEntityTypesT::IfcGeometricRepresentationItem>(), carve::math::Matrix::IDENT(), itemData);
 	}
 
 #ifdef _DEBUG

--- a/Core/src/IfcGeometryConverter/IfcImporterImpl.h
+++ b/Core/src/IfcGeometryConverter/IfcImporterImpl.h
@@ -95,7 +95,7 @@ static void OpenInfraPlatform::Core::IfcGeometryConverter::IfcImporterUtil::conv
 #ifdef _DEBUG
 			BLUE_LOG(trace) << "Processing IfcRepresentation #" << rep->getId();
 #endif
-			repConverter->convertIfcRepresentation(rep.lock(), matProduct, productShape, strerr);
+			repConverter->convertIfcRepresentation(rep.lock(), matProduct, productShape);
 #ifdef _DEBUG
 			BLUE_LOG(trace) << "Processed IfcRepresentation #" << rep->getId();
 #endif

--- a/Core/src/IfcGeometryConverter/PlacementConverter.h
+++ b/Core/src/IfcGeometryConverter/PlacementConverter.h
@@ -69,6 +69,35 @@ namespace OpenInfraPlatform {
 
                     }
 
+					/*! \brief Converts \c IfcPoint to a vector.
+
+					\param[in]	point	\c IfcPoint entity to be interpreted.
+
+					\return		Calculated 2D or 3D vector.
+
+					\note The point's coordinates are scaled according to the unit conversion factor.
+					\note The point's coordinates are reset to (0,0,0).
+					*/
+					carve::geom::vector<3> convertIfcPoint(
+						const EXPRESSReference<typename IfcEntityTypesT::IfcPoint>& point
+					)
+					{
+						// **************************************************************************************************************************
+						// ENTITY IfcPoint
+						//  https://standards.buildingsmart.org/IFC/RELEASE/IFC4_1/FINAL/HTML/schema/ifcgeometryresource/lexical/ifcpoint.htm
+						// ABSTRACT SUPERTYPE OF(ONEOF(IfcCartesianPoint, IfcPointOnCurve, IfcPointOnSurface))
+						//	SUBTYPE OF(IfcGeometricRepresentationItem);
+						// END_ENTITY;
+						// **************************************************************************************************************************
+
+						// IfcCartesianPoint
+						if (point.isOfType<typename IfcEntityTypesT::IfcCartesianPoint>())
+							return convertIfcCartesianPoint(point.as<typename IfcEntityTypesT::IfcCartesianPoint>());
+
+						// the rest is not supported
+						throw UnhandledException(point);
+
+					}
                     /*! \brief Converts \c IfcCartesianPoint to a vector.
 
                     \param[in]	cartesianPoint	\c IfcCartesianPoint entity to be interpreted.

--- a/Core/src/IfcGeometryConverter/PlacementConverter.h
+++ b/Core/src/IfcGeometryConverter/PlacementConverter.h
@@ -80,7 +80,7 @@ namespace OpenInfraPlatform {
 					*/
 					carve::geom::vector<3> convertIfcPoint(
 						const EXPRESSReference<typename IfcEntityTypesT::IfcPoint>& point
-					)
+					) const throw(...)
 					{
 						// **************************************************************************************************************************
 						// ENTITY IfcPoint
@@ -109,7 +109,7 @@ namespace OpenInfraPlatform {
                     */
 					carve::geom::vector<3> convertIfcCartesianPoint(
                         const EXPRESSReference<typename IfcEntityTypesT::IfcCartesianPoint>& cartesianPoint
-                        )
+                        ) const noexcept
                     {
                         // **************************************************************************************************************************
                         // IfcCartesianPoint
@@ -212,9 +212,7 @@ namespace OpenInfraPlatform {
 
                         // (1/3) IfcAxis1Placement SUBTYPE OF IfcPlacement
                         if(std::dynamic_pointer_cast<typename IfcEntityTypesT::IfcAxis1Placement>(placement)) {
-                            BLUE_LOG(error) << placement->getErrorLog() << ": Not implemented.";
                             throw UnhandledException(placement);
-                            return;
                         }
 
                         // (2/3) IfcAxis2Placement2D SUBTYPE OF IfcPlacement 
@@ -233,7 +231,7 @@ namespace OpenInfraPlatform {
                             return;
                         }
 
-                        BLUE_LOG(error) << placement->getErrorLog() << ": Not supported.";
+						throw UnhandledException(placement);
                     }
 
                     /*! \brief Converts \c IfcAxis2Placement2D to a transformation matrix.

--- a/Core/src/IfcGeometryConverter/PlacementConverter.h
+++ b/Core/src/IfcGeometryConverter/PlacementConverter.h
@@ -101,14 +101,15 @@ namespace OpenInfraPlatform {
                     /*! \brief Converts \c IfcCartesianPoint to a vector.
 
                     \param[in]	cartesianPoint	\c IfcCartesianPoint entity to be interpreted.
-                    \param[out] point			Calculated 2D or 3D vector.
+
+                    \return		Calculated 2D or 3D vector.
 
                     \note The point's coordinates are scaled according to the unit conversion factor.
                     \note The point's coordinates are reset to (0,0,0).
                     */
-                    void convertIfcCartesianPoint(
-                        const std::shared_ptr<typename IfcEntityTypesT::IfcCartesianPoint>& cartesianPoint,
-                        carve::geom::vector<3>& point)
+					carve::geom::vector<3> convertIfcCartesianPoint(
+                        const EXPRESSReference<typename IfcEntityTypesT::IfcCartesianPoint>& cartesianPoint
+                        )
                     {
                         // **************************************************************************************************************************
                         // IfcCartesianPoint
@@ -124,7 +125,7 @@ namespace OpenInfraPlatform {
                         // **************************************************************************************************************************
 
                         // set to default
-                        point = carve::geom::VECTOR(0.0, 0.0, 0.0);
+						carve::geom::vector<3> point = carve::geom::VECTOR(0.0, 0.0, 0.0);
                         // read the coordinates
                         auto& coords = cartesianPoint->Coordinates;
                         if(coords.size() > 0) {
@@ -141,6 +142,8 @@ namespace OpenInfraPlatform {
                         }
                         // scale the lengths according to the unit conversion
                         point *= UnitConvert()->getLengthInMeterFactor();
+						// returns
+						return point;
                     }
 
                     /*! \brief Converts \c IfcDirection to a vector.

--- a/Core/src/IfcGeometryConverter/PlacementConverter.h
+++ b/Core/src/IfcGeometryConverter/PlacementConverter.h
@@ -265,7 +265,7 @@ namespace OpenInfraPlatform {
                         carve::geom::vector<3>  ref_direction(carve::geom::VECTOR(1.0, 0.0, 0.0)); // defaults to (1.0,0.0) according to the specification
 
                         // interpret Location 
-                        convertIfcCartesianPoint(axis2placement2d->Location.lock(), translate);
+						translate = convertIfcCartesianPoint( axis2placement2d->Location );
 
                         // interpret RefDirection [OPTIONAL]
                         if(axis2placement2d->RefDirection) {
@@ -324,7 +324,7 @@ namespace OpenInfraPlatform {
                         carve::geom::vector<3>  ref_direction(carve::geom::VECTOR(1.0, 0.0, 0.0));
 
                         // interpret Location
-                        convertIfcCartesianPoint(axis2placement3d->Location.lock(), translate);
+						translate = convertIfcCartesianPoint(axis2placement3d->Location);
 
                         // interpret RefDirection [OPTIONAL]
                         if(axis2placement3d->RefDirection) {
@@ -1542,8 +1542,7 @@ namespace OpenInfraPlatform {
                             bool bCCW = (curveOut ? bCCWStart : bCCWEnd);
 
                             //  Starting point of the segment
-                            carve::geom::vector<3> startPoint;
-                            convertIfcCartesianPoint(curveSegStartPoint, startPoint);
+                            carve::geom::vector<3> startPoint = convertIfcCartesianPoint(curveSegStartPoint);
 
                             // the transformation matrix
                             carve::math::Matrix matrix(carve::math::Matrix::IDENT());

--- a/Core/src/IfcGeometryConverter/RepresentationConverter.h
+++ b/Core/src/IfcGeometryConverter/RepresentationConverter.h
@@ -82,12 +82,14 @@ namespace OpenInfraPlatform {
 				{
 				}
 
-				// *************************************************************************************************************************************************************//
-				//	IfcRepresentationItem	(http://www.buildingsmart-tech.org/ifc/IFC4x1/final/html/schema/ifcgeometryresource/lexical/ifcgeometricrepresentationitem.htm)		//
-				//	ABSTRACT SUPERTYPE OF IfcGeometricRepresentationItem, IfcMappedItem, IfcStyledItem, IfcTopologicalRepresentationItem										//
-				// *************************************************************************************************************************************************************//
-
-				void convertIfcRepresentation(const std::shared_ptr<typename IfcEntityTypesT::IfcRepresentation>& representation,
+				/*! \brief Converts \c IfcRepresentation to meshes.
+				*
+				* \param[in] representation The \c IfcRepresentation to be converted.
+				* \param[in] objectPlacement The relative location of the origin of the representation's coordinate system within the global system.
+				* \param[out] inputData A pointer to be filled with the relevant data.
+				*/
+				void convertIfcRepresentation(
+					const EXPRESSReference<typename IfcEntityTypesT::IfcRepresentation>& representation,
 					const carve::math::Matrix& objectPlacement,
 					std::shared_ptr<ShapeInputDataT<IfcEntityTypesT>>& inputData)
 				{
@@ -107,160 +109,21 @@ namespace OpenInfraPlatform {
 					// END_ENTITY;
 					// **************************************************************************************************************************
 
-					double length_factor = UnitConvert()->getLengthInMeterFactor();
-
-					for(auto it_representation_items : representation->Items) {
-						
+					// loop over all RepresentationItems
+					for (auto& it_representation_item : representation->Items)
+					{
+						// catch UnhandledException
 						try
 						{
+							// the data of the item
+							std::shared_ptr<ItemData> itemData(new ItemData());
 
-						std::shared_ptr<typename IfcEntityTypesT::IfcRepresentationItem>& representation_item = it_representation_items.lock();
-						std::shared_ptr<ItemData> itemData(new ItemData());
-						inputData->vec_item_data.push_back(itemData);
+							// call the converter
+							convertIfcRepresentationItem(it_representation_item, objectPlacement, itemData);
 
-						// (1/4) IfcGeometricRepresenationItem SUBTYPE OF IfcRepresentationItem
-						if( isOfType<typename IfcEntityTypesT::IfcGeometricRepresentationItem>(representation_item) ) 
-						{
-							convertIfcGeometricRepresentationItem(
-								it_representation_items.as<typename IfcEntityTypesT::IfcGeometricRepresentationItem>(),
-								objectPlacement, itemData);
-							continue;
+							// only add if no exception was thrown
+							inputData->vec_item_data.push_back(itemData);
 						}
-
-						// (2/4) IfcMappedItem SUBTYPE OF IfcRepresentationItem
-						if( isOfType<typename IfcEntityTypesT::IfcMappedItem>(representation_item) ) 
-						{
-							// decltype(mapped_item->MappingSource)::type &map_source = mapped_item->MappingSource;
-							std::shared_ptr<typename IfcEntityTypesT::IfcMappedItem> mapped_item = std::dynamic_pointer_cast<typename IfcEntityTypesT::IfcMappedItem>(representation_item);
-							auto& map_source = mapped_item->MappingSource;
-
-							if(!map_source.lock()) {
-								BLUE_LOG(warning) << "unhandled representation: #" << representation_item->getId() << " = " << representation_item->classname();
-								continue;
-							}
-
-							// decltype(map_source->Mapped_Representation)::type &mapped_representation = map_source->MappedRepresentation;
-							auto& mapped_representation = map_source->MappedRepresentation;
-							if(!mapped_representation.lock()) {
-								BLUE_LOG(warning) << "unhandled representation: #" << representation_item->getId() << " = " << representation_item->classname();
-								continue;
-							}
-
-							carve::math::Matrix map_matrix_target(carve::math::Matrix::IDENT());
-							if(mapped_item->MappingTarget) {
-								auto& transform_operator = mapped_item->MappingTarget;
-
-								PlacementConverterT<IfcEntityTypesT>::convertTransformationOperator(transform_operator.lock(), map_matrix_target, UnitConvert()->getLengthInMeterFactor());
-							}
-
-							carve::math::Matrix map_matrix_origin(carve::math::Matrix::IDENT());
-							typename IfcEntityTypesT::IfcAxis2Placement mapping_origin_select = map_source->MappingOrigin;
-
-							std::shared_ptr<typename IfcEntityTypesT::IfcPlacement> mapping_origin_placement = nullptr;
-
-							switch(mapping_origin_select.which()) {
-							case 0: mapping_origin_placement = std::dynamic_pointer_cast<typename IfcEntityTypesT::IfcPlacement>(mapping_origin_select.get<0>().lock()); break;
-							case 1: mapping_origin_placement = std::dynamic_pointer_cast<typename IfcEntityTypesT::IfcPlacement>(mapping_origin_select.get<1>().lock()); break;
-							default: break;
-							}
-
-							if(mapping_origin_placement) {
-								placementConverter->convertIfcPlacement(mapping_origin_placement, map_matrix_origin);
-							}
-							else {
-								BLUE_LOG(warning) << "#" << mapping_origin_placement->getId() << " = IfcPlacement: !std::dynamic_pointer_cast<IfcPlacement>( mapping_origin ) )";
-								continue;
-							}
-
-
-							carve::math::Matrix mapped_pos((map_matrix_origin * objectPlacement) * map_matrix_target);
-
-							convertIfcRepresentation(mapped_representation.lock(), mapped_pos, inputData);
-#ifdef _DEBUG
-							BLUE_LOG(trace) << "Processed IfcMappedItem #" << mapped_representation.lock()->getId();
-#endif
-							continue;
-						}
-
-						// (3/4) IfcStyledItem SUBTYPE OF IfcRepresentationItem
-						if( isOfType<typename IfcEntityTypesT::IfcStyledItem>(representation_item) ) 
-						{
-							// call the corresponding function
-							convertIfcStyledItem(std::dynamic_pointer_cast<typename IfcEntityTypesT::IfcStyledItem>(representation_item), itemData );
-							continue;
-						}
-
-						// (4/4) IfcTopologicalRepresentationItem SUBTYPE OF IfcRepresentationItem
-						if( isOfType<typename IfcEntityTypesT::IfcTopologicalRepresentationItem>(representation_item) ) {
-							// IfcTopologicalRepresentationItem ABSTRACT SUPERTYPE OF IfcConnectedFaceSet, IfcEdge, IfcFace*, IfcFaceBound*, IfcLoop*, IfcPath*, IfcVertex*.
-							std::shared_ptr<typename IfcEntityTypesT::IfcTopologicalRepresentationItem> topo_item =
-								std::dynamic_pointer_cast<typename IfcEntityTypesT::IfcTopologicalRepresentationItem>(representation_item);
-
-							// IfcConnectedFaceSet SUBTYPE OF IfcTopologicalRepresentationItem
-							std::shared_ptr<typename IfcEntityTypesT::IfcConnectedFaceSet> topo_connected_face_set =
-								std::dynamic_pointer_cast<typename IfcEntityTypesT::IfcConnectedFaceSet>(topo_item);
-							if(topo_connected_face_set) {
-								BLUE_LOG(warning) << "#" << topo_item->getId() << " = IfcTopologicalRepresentationItem: #" << topo_connected_face_set ->getId() << " = IfcConnectedFaceSet not implemented yet";
-								continue;
-							}
-
-							// IfcEdge SUBTYPE OF IfcTopologicalRepresentationItem
-							std::shared_ptr<typename IfcEntityTypesT::IfcEdge> topo_edge = std::dynamic_pointer_cast<typename IfcEntityTypesT::IfcEdge>(topo_item);
-							if(topo_edge) {
-								std::shared_ptr<carve::input::PolylineSetData> polyline_data(new carve::input::PolylineSetData());
-								polyline_data->beginPolyline();
-
-								// decltype(vertex_start = topo_edge->EdgeStart)::type& vertex_start = topo_edge->EdgeStart;
-								auto& vertex_start = topo_edge->EdgeStart;
-
-								std::shared_ptr<typename IfcEntityTypesT::IfcVertexPoint> vertex_start_point =
-									std::dynamic_pointer_cast<typename IfcEntityTypesT::IfcVertexPoint>(vertex_start.lock());
-
-								if(vertex_start_point) {
-									if(vertex_start_point->VertexGeometry) {
-										auto& edge_start_point_geometry = vertex_start_point->VertexGeometry;
-
-										std::shared_ptr<typename IfcEntityTypesT::IfcCartesianPoint> ifc_point =
-											std::dynamic_pointer_cast<typename IfcEntityTypesT::IfcCartesianPoint>(edge_start_point_geometry.lock());
-										if(ifc_point) {
-											if(ifc_point->Coordinates.size() > 2) {
-												carve::geom::vector<3> point = carve::geom::VECTOR(ifc_point->Coordinates[0] * length_factor, ifc_point->Coordinates[1] * length_factor,
-													ifc_point->Coordinates[2] * length_factor);
-
-												polyline_data->addVertex(objectPlacement * point);
-												polyline_data->addPolylineIndex(0);
-											}
-										}
-									}
-								}
-
-								// decltype(topo_edge->EdgeEnd)::type& vertex_end = topo_edge->EdgeEnd;
-								auto& vertex_end = topo_edge->EdgeEnd;
-								std::shared_ptr<typename IfcEntityTypesT::IfcVertexPoint> vertex_end_point =
-									std::dynamic_pointer_cast<typename IfcEntityTypesT::IfcVertexPoint>(vertex_end.lock());
-								if(vertex_end_point) {
-									if(vertex_end_point->VertexGeometry) {
-										auto& edge_point_geometry = vertex_end_point->VertexGeometry;
-
-										std::shared_ptr<typename IfcEntityTypesT::IfcCartesianPoint> ifc_point =
-											std::dynamic_pointer_cast<typename IfcEntityTypesT::IfcCartesianPoint>(edge_point_geometry.lock());
-										if(ifc_point) {
-											if(ifc_point->Coordinates.size() > 2) {
-												carve::geom::vector<3> point = carve::geom::VECTOR(ifc_point->Coordinates[0] * length_factor, ifc_point->Coordinates[1] * length_factor,
-													ifc_point->Coordinates[2] * length_factor);
-
-												polyline_data->addVertex(objectPlacement * point);
-												polyline_data->addPolylineIndex(1);
-											}
-										}
-									}
-								}
-								itemData->polylines.push_back(polyline_data);
-								continue;
-							}
-						}
-
-						} // end try
 						catch (const UnhandledException& ex)
 						{
 							BLUE_LOG(error) << ex.what();
@@ -271,9 +134,10 @@ namespace OpenInfraPlatform {
 							BLUE_LOG(error) << "Unknown exception";
 							throw;
 						}
-						//err << "unhandled representation: #" << representation_item->getId() << " = " << representation_item->classname() << std::endl;
+
 					} // end for each representation item
 
+					//TODO remaining handle layer assignments (requires INVERSE)
 					if(handle_layer_assignments) {
 						// std::vector<std::weak_ptr<typename IfcEntityTypesT::IfcPresentationLayerAssignment>>& LayerAssignments_inverse =
 						//	representation->LayerAssignments_inverse;
@@ -300,6 +164,149 @@ namespace OpenInfraPlatform {
 					}
 				}
 
+				/*! \brief Converts \c IfcRepresentationItem to meshes.
+				*
+				* \param[in] reprItem The \c IfcRepresentationItem to be converted.
+				* \param[in] objectPlacement The relative location of the origin of the representation's coordinate system within the global system.
+				* \param[out] itemData A pointer to be filled with the relevant data.
+				*/
+				void convertIfcRepresentationItem(
+					const EXPRESSReference<typename IfcEntityTypesT::IfcRepresentationItem>& reprItem,
+					const carve::math::Matrix& objectPlacement,
+					std::shared_ptr<ItemData> itemData
+				) throw(...)
+				{
+					// *************************************************************************************************************************************************************//
+					//	IfcRepresentationItem	
+					//   https://standards.buildingsmart.org/IFC/RELEASE/IFC4_1/FINAL/HTML/schema/ifcgeometryresource/lexical/ifcrepresentationitem.htm
+					//	ABSTRACT SUPERTYPE OF IfcGeometricRepresentationItem, IfcMappedItem, IfcStyledItem, IfcTopologicalRepresentationItem										//
+					// *************************************************************************************************************************************************************//
+
+					// (1/4) IfcGeometricRepresenationItem SUBTYPE OF IfcRepresentationItem
+					if (reprItem.isOfType<typename IfcEntityTypesT::IfcGeometricRepresentationItem>())
+					{
+						// convert as IfcGeometricRepresentationItem
+						convertIfcGeometricRepresentationItem(
+							reprItem.as<typename IfcEntityTypesT::IfcGeometricRepresentationItem>(),
+							objectPlacement, itemData);
+						return;
+					}
+
+					// (2/4) IfcMappedItem SUBTYPE OF IfcRepresentationItem
+					if (reprItem.isOfType<typename IfcEntityTypesT::IfcMappedItem>())
+					{
+						// decltype(mapped_item->MappingSource)::type &map_source = mapped_item->MappingSource;
+						auto mapped_item = reprItem.as<typename IfcEntityTypesT::IfcMappedItem>();
+						auto& map_source = mapped_item->MappingSource;
+
+						if (!map_source.lock()) {
+							throw UnhandledException(reprItem);
+							return;
+						}
+
+						// decltype(map_source->Mapped_Representation)::type &mapped_representation = map_source->MappedRepresentation;
+						auto& mapped_representation = map_source->MappedRepresentation;
+						if (!mapped_representation.lock()) {
+							throw UnhandledException(reprItem);
+							return;
+						}
+
+						carve::math::Matrix map_matrix_target(carve::math::Matrix::IDENT());
+						if (mapped_item->MappingTarget) {
+							auto& transform_operator = mapped_item->MappingTarget;
+
+							PlacementConverterT<IfcEntityTypesT>::convertTransformationOperator(transform_operator.lock(), map_matrix_target, UnitConvert()->getLengthInMeterFactor());
+						}
+
+						carve::math::Matrix map_matrix_origin(carve::math::Matrix::IDENT());
+						typename IfcEntityTypesT::IfcAxis2Placement mapping_origin_select = map_source->MappingOrigin;
+
+						std::shared_ptr<typename IfcEntityTypesT::IfcPlacement> mapping_origin_placement = nullptr;
+
+						switch (mapping_origin_select.which()) {
+						case 0: mapping_origin_placement = std::dynamic_pointer_cast<typename IfcEntityTypesT::IfcPlacement>(mapping_origin_select.get<0>().lock()); break;
+						case 1: mapping_origin_placement = std::dynamic_pointer_cast<typename IfcEntityTypesT::IfcPlacement>(mapping_origin_select.get<1>().lock()); break;
+						default: break;
+						}
+
+						if (mapping_origin_placement) {
+							placementConverter->convertIfcPlacement(mapping_origin_placement, map_matrix_origin);
+						}
+						else {
+							BLUE_LOG(warning) << "#" << mapping_origin_placement->getId() << " = IfcPlacement: !std::dynamic_pointer_cast<IfcPlacement>( mapping_origin ) )";
+							return;
+						}
+
+
+						carve::math::Matrix mapped_pos((map_matrix_origin * objectPlacement) * map_matrix_target);
+
+						std::shared_ptr<ShapeInputDataT<IfcEntityTypesT>>& inputData
+							= std::make_shared<ShapeInputDataT<IfcEntityTypesT>>();
+						convertIfcRepresentation(mapped_representation, mapped_pos, inputData);
+
+						std::for_each(  inputData->vec_item_data.begin(),
+										inputData->vec_item_data.end(),
+										[&](const std::shared_ptr<ItemData>& data) { itemData->append(data); });
+#ifdef _DEBUG
+						BLUE_LOG(trace) << "Processed IfcMappedItem #" << mapped_representation.lock()->getId();
+#endif
+						return;
+					}
+
+					// (3/4) IfcStyledItem SUBTYPE OF IfcRepresentationItem
+					if (reprItem.isOfType<typename IfcEntityTypesT::IfcStyledItem>())
+					{
+						// call the corresponding function
+						convertIfcStyledItem(reprItem.as<typename IfcEntityTypesT::IfcStyledItem>(), itemData);
+						return;
+					}
+
+					// (4/4) IfcTopologicalRepresentationItem SUBTYPE OF IfcRepresentationItem
+					if (reprItem.isOfType<typename IfcEntityTypesT::IfcTopologicalRepresentationItem>()) {
+						// IfcTopologicalRepresentationItem ABSTRACT SUPERTYPE OF IfcConnectedFaceSet, IfcEdge, IfcFace*, IfcFaceBound*, IfcLoop*, IfcPath*, IfcVertex*.
+						EXPRESSReference<typename IfcEntityTypesT::IfcTopologicalRepresentationItem> topo_item =
+							reprItem.as<typename IfcEntityTypesT::IfcTopologicalRepresentationItem>();
+
+						// IfcConnectedFaceSet SUBTYPE OF IfcTopologicalRepresentationItem
+						if (topo_item.isOfType<typename IfcEntityTypesT::IfcConnectedFaceSet>() ) {
+							throw UnhandledException(topo_item);
+							return;
+						}
+
+						// IfcEdge SUBTYPE OF IfcTopologicalRepresentationItem
+						std::shared_ptr<typename IfcEntityTypesT::IfcEdge> topo_edge = std::dynamic_pointer_cast<typename IfcEntityTypesT::IfcEdge>(topo_item.lock());
+						if (topo_edge) {
+							std::shared_ptr<carve::input::PolylineSetData> polyline_data(new carve::input::PolylineSetData());
+							polyline_data->beginPolyline();
+
+							// decltype(vertex_start = topo_edge->EdgeStart)::type& vertex_start = topo_edge->EdgeStart;
+							auto& vertex_start = topo_edge->EdgeStart;
+
+							std::shared_ptr<typename IfcEntityTypesT::IfcVertexPoint> vertex_start_point =
+								std::dynamic_pointer_cast<typename IfcEntityTypesT::IfcVertexPoint>(vertex_start.lock());
+							if (vertex_start_point) {
+								carve::geom::vector<3> point = placementConverter->convertIfcPoint(vertex_start_point->VertexGeometry);
+
+								polyline_data->addVertex(objectPlacement * point);
+								polyline_data->addPolylineIndex(0);
+							}
+
+							// decltype(topo_edge->EdgeEnd)::type& vertex_end = topo_edge->EdgeEnd;
+							auto& vertex_end = topo_edge->EdgeEnd;
+							std::shared_ptr<typename IfcEntityTypesT::IfcVertexPoint> vertex_end_point =
+								std::dynamic_pointer_cast<typename IfcEntityTypesT::IfcVertexPoint>(vertex_end.lock());
+							if (vertex_end_point) {
+								carve::geom::vector<3> point = placementConverter->convertIfcPoint(vertex_end_point->VertexGeometry);
+
+								polyline_data->addVertex(objectPlacement * point);
+								polyline_data->addPolylineIndex(1);
+							}
+							itemData->polylines.push_back(polyline_data);
+							return;
+						}
+					}
+				}
+
 				// *********************************************************************************************************************************************************************//
 				//	IfcGeometricRepresentationItem	 (http://www.buildingsmart-tech.org/ifc/IFC4x1/final/html/schema/ifcgeometryresource/lexical/ifcgeometricrepresentationitem.htm)
 				//// 	ABSTRACT SUPERTYPE OF IfcAnnotationFillArea, IfcBooleanResult, IfcBoundingBox, IfcCartesianTransformationOperator, IfcCompositeCurveSegment, IfcCsgPrimitive3D,
@@ -308,7 +315,8 @@ namespace OpenInfraPlatform {
 				//	IfcShellBasedSurfaceModel, IfcSolidModel, IfcSurface, IfcTextLiteral, IfcTextureCoordinate, IfcTextureVertex, IfcVector. //
 				// *********************************************************************************************************************************************************************//
 
-				void convertIfcGeometricRepresentationItem(EXPRESSReference<typename IfcEntityTypesT::IfcGeometricRepresentationItem>& geomItem,
+				void convertIfcGeometricRepresentationItem(
+					const EXPRESSReference<typename IfcEntityTypesT::IfcGeometricRepresentationItem>& geomItem,
 					const carve::math::Matrix& pos,
 					std::shared_ptr<ItemData> itemData)
 				{
@@ -595,13 +603,16 @@ namespace OpenInfraPlatform {
 
 				/*!
 				 * \internal TODO
+				 *
+				 * The function is not implemented.
 				 */
 				void convertIfcStyledItem(
-					const std::shared_ptr<typename IfcEntityTypesT::IfcRepresentationItem>& representation_item, 
-					std::shared_ptr<ItemData>& itemData)
+					const EXPRESSReference<typename IfcEntityTypesT::IfcStyledItem>& styledItem, 
+					std::shared_ptr<ItemData>& itemData) throw(...)
 				{
-					//throw UnhandledException( representation_item );
+					throw UnhandledException( styledItem );
 
+					// code left here for reference, for the future poor soul taking care of styled items
 					//std::vector<std::weak_ptr<typename IfcEntityTypesT::IfcStyledItem>>& StyledByItem_inverse_vec = representation_item->StyledByItem_inverse;
 					//for(unsigned int i = 0; i < StyledByItem_inverse_vec.size(); ++i) {
 					//	std::weak_ptr<typename IfcEntityTypesT::IfcStyledItem> styled_item_weak = StyledByItem_inverse_vec[i];

--- a/Core/src/IfcGeometryConverter/RepresentationConverter.h
+++ b/Core/src/IfcGeometryConverter/RepresentationConverter.h
@@ -49,12 +49,21 @@
 namespace OpenInfraPlatform {
 	namespace Core {
 		namespace IfcGeometryConverter {
+
+			/*! \brief The top converter class.
+			 *
+			 * This class includes top-level converter functions and calls other converters correspondingly.
+			 * This should be used as an entry point to the geometry converter functionalities.
+			 *
+			 * \param IfcEntityTypesT The IFC version templates
+			 */
 			template <
 				class IfcEntityTypesT
 			>
 			class RepresentationConverterT : public ConverterBaseT<IfcEntityTypesT>
 			{
 			public:
+				//! Constructor
 				RepresentationConverterT(
 					std::shared_ptr<GeometrySettings> geomSettings, 
 					std::shared_ptr<UnitConverter<IfcEntityTypesT>> unitConverter
@@ -78,6 +87,7 @@ namespace OpenInfraPlatform {
 						std::make_shared<SolidModelConverterT<IfcEntityTypesT>>(geomSettings, unitConverter, placementConverter, curveConverter, faceConverter, profileCache);
 				}
 
+				//! Destructor
 				~RepresentationConverterT()
 				{
 				}
@@ -91,7 +101,8 @@ namespace OpenInfraPlatform {
 				void convertIfcRepresentation(
 					const EXPRESSReference<typename IfcEntityTypesT::IfcRepresentation>& representation,
 					const carve::math::Matrix& objectPlacement,
-					std::shared_ptr<ShapeInputDataT<IfcEntityTypesT>>& inputData)
+					std::shared_ptr<ShapeInputDataT<IfcEntityTypesT>>& inputData
+				) const noexcept
 				{
 					// **************************************************************************************************************************
 					// IfcRepresentation
@@ -126,13 +137,13 @@ namespace OpenInfraPlatform {
 						}
 						catch (const UnhandledException& ex)
 						{
+							// write the error to the console
 							BLUE_LOG(error) << ex.what();
 							continue;
 						}
 						catch (...)
 						{
 							BLUE_LOG(error) << "Unknown exception";
-							throw;
 						}
 
 					} // end for each representation item
@@ -165,16 +176,16 @@ namespace OpenInfraPlatform {
 				}
 
 				/*! \brief Converts \c IfcRepresentationItem to meshes.
-				*
-				* \param[in] reprItem The \c IfcRepresentationItem to be converted.
-				* \param[in] objectPlacement The relative location of the origin of the representation's coordinate system within the global system.
-				* \param[out] itemData A pointer to be filled with the relevant data.
-				*/
+				 *
+				 * \param[in] reprItem The \c IfcRepresentationItem to be converted.
+				 * \param[in] objectPlacement The relative location of the origin of the representation's coordinate system within the global system.
+				 * \param[out] itemData A pointer to be filled with the relevant data.
+				 */
 				void convertIfcRepresentationItem(
 					const EXPRESSReference<typename IfcEntityTypesT::IfcRepresentationItem>& reprItem,
 					const carve::math::Matrix& objectPlacement,
-					std::shared_ptr<ItemData> itemData
-				) throw(...)
+					std::shared_ptr<ItemData>& itemData
+				) const throw(...)
 				{
 					// *************************************************************************************************************************************************************//
 					//	IfcRepresentationItem	
@@ -318,7 +329,8 @@ namespace OpenInfraPlatform {
 				void convertIfcGeometricRepresentationItem(
 					const EXPRESSReference<typename IfcEntityTypesT::IfcGeometricRepresentationItem>& geomItem,
 					const carve::math::Matrix& pos,
-					std::shared_ptr<ItemData> itemData)
+					std::shared_ptr<ItemData>& itemData
+				) const throw(...)
 				{
 					// (1/9) IfcFaceBasedSurfaceModel SUBTYPE OF IfcGeometricRepresentationItem
 					if(geomItem.isOfType<typename IfcEntityTypesT::IfcFaceBasedSurfaceModel>()) {
@@ -550,20 +562,21 @@ namespace OpenInfraPlatform {
 				// ****************************************************************************************************************************************	//
 
 				// Function 1:  Convert version specific IfcGeometricRepresentationItem,
-				bool convertVersionSpecificIfcGeometricRepresentationItem(const std::shared_ptr<typename IfcEntityTypesT::IfcGeometricRepresentationItem>& geomItem,
+				bool convertVersionSpecificIfcGeometricRepresentationItem(
+					const std::shared_ptr<typename IfcEntityTypesT::IfcGeometricRepresentationItem>& geomItem,
 					const carve::math::Matrix& pos,
-					std::shared_ptr<ItemData> itemData)
+					std::shared_ptr<ItemData>& itemData
+				) const throw(...)
 				{
-#ifdef _DEBUG
-					std::cout << "Warning\t| Could not find other version specific geometric representations" << std::endl;
-#endif
+					throw UnhandledException(geomItem);
 					return false;
 				}
 
 				// Function 2:  Convert IfcSectionedSpine,
 				void convertIfcSectionedSpine(const std::shared_ptr<typename IfcEntityTypesT::IfcSectionedSpine>& spine,
 					const carve::math::Matrix& pos,
-					std::shared_ptr<ItemData> itemData)
+					std::shared_ptr<ItemData>& itemData
+				) const 
 				{
 					const std::shared_ptr<typename IfcEntityTypesT::IfcCompositeCurve> spine_curve = spine->SpineCurve.lock();
 					if(!spine_curve) {
@@ -608,7 +621,8 @@ namespace OpenInfraPlatform {
 				 */
 				void convertIfcStyledItem(
 					const EXPRESSReference<typename IfcEntityTypesT::IfcStyledItem>& styledItem, 
-					std::shared_ptr<ItemData>& itemData) throw(...)
+					std::shared_ptr<ItemData>& itemData
+				) const throw(...)
 				{
 					throw UnhandledException( styledItem );
 

--- a/Core/src/IfcGeometryConverter/SolidModelConverter.h
+++ b/Core/src/IfcGeometryConverter/SolidModelConverter.h
@@ -928,8 +928,7 @@ namespace OpenInfraPlatform
 
 					if (axis_placement->Location)
 					{
-						std::shared_ptr<typename IfcEntityTypesT::IfcCartesianPoint> location_point = axis_placement->Location.lock();
-						placementConverter->convertIfcCartesianPoint(location_point, axis_location);
+						axis_location = placementConverter->convertIfcCartesianPoint(axis_placement->Location );
 					}
 
 					if (axis_placement->Axis)
@@ -1636,13 +1635,11 @@ namespace OpenInfraPlatform
 							BLUE_LOG(error) << "IfcBoxedHalfSpace: Enclosure not valid!";
 							return;
 						}
-						std::shared_ptr<typename IfcEntityTypesT::IfcCartesianPoint>	bbox_corner = bbox->Corner.lock();
 						typename IfcEntityTypesT::IfcLengthMeasure	bbox_x_dim = bbox->XDim;
 						typename IfcEntityTypesT::IfcLengthMeasure	bbox_y_dim = bbox->YDim;
 						typename IfcEntityTypesT::IfcLengthMeasure	bbox_z_dim = bbox->ZDim;
 
-						carve::geom::vector<3> corner;
-						placementConverter->convertIfcCartesianPoint(bbox_corner, corner);
+						carve::geom::vector<3> corner = placementConverter->convertIfcCartesianPoint(bbox->Corner);
 						carve::math::Matrix box_position_matrix = pos * base_position_matrix*carve::math::Matrix::TRANS(corner);
 
 						// else, its an unbounded half space solid, create simple box

--- a/Core/src/IfcGeometryConverter/UnhandledException.h
+++ b/Core/src/IfcGeometryConverter/UnhandledException.h
@@ -26,6 +26,7 @@
 #include "CarveHeaders.h"
 
 #include "EXPRESS/EXPRESSObject.h"
+#include "EXPRESS\EXPRESSReference.h"
 
 namespace OpenInfraPlatform {
 	namespace Core {
@@ -52,6 +53,15 @@ namespace OpenInfraPlatform {
 				UnhandledException(const std::shared_ptr<oip::EXPRESSObject>& item) noexcept
 				{
 					item_ = item;
+				}
+				/*!
+				\brief Constructor with the unhandled entity.
+				\param[in] item The entity that is not handled.
+				*/
+				template <typename T>
+				UnhandledException(const oip::EXPRESSReference<typename T>& item) noexcept
+				{
+					item_ = item.lock();
 				}
 				//! Destructor
 				~UnhandledException() throw()

--- a/EarlyBinding/src/EXPRESS/EXPRESSReference.h
+++ b/EarlyBinding/src/EXPRESS/EXPRESSReference.h
@@ -127,4 +127,6 @@ private:
 OIP_NAMESPACE_OPENINFRAPLATFORM_EARLYBINDING_END
 
 template<typename T> using EXPRESSReference = OpenInfraPlatform::EarlyBinding::EXPRESSReference<T>;
+EMBED_INTO_OIP_NAMESPACE(EXPRESSReference);
+
 #endif // end define OpenInfraPlatform_EarlyBinding_EXPRESSReference_c5a3045b_df30_4a77_aeea_3a16cde5c141_h

--- a/EarlyBinding/src/EXPRESS/SelectType.h
+++ b/EarlyBinding/src/EXPRESS/SelectType.h
@@ -87,7 +87,16 @@ public:
 		return boost::get<std::tuple_element_t<Index, std::tuple<Args...>>>(base::m_value);
 	}
 
+	template <size_t Index> auto get() const -> std::tuple_element_t<Index, std::tuple<Args...>> {
+		return boost::get<std::tuple_element_t<Index, std::tuple<Args...>>>(base::m_value);
+	}
+
 	template <class T> T get() {
+		static_assert(boost::detail::variant::holds_element<Select, T >::value, "Cast to type is not defined.");
+		return boost::get<T>(base::m_value);
+	}
+
+	template <class T> const T get() const {
 		static_assert(boost::detail::variant::holds_element<Select, T >::value, "Cast to type is not defined.");
 		return boost::get<T>(base::m_value);
 	}


### PR DESCRIPTION
It compiles, but at runtime, gibberish comes out. 

The problem happens for example while converting a `IfcCartesianPoint` in `PlacementConverterT::convertIfcCartesianPoint(..)`.
I suspect that by passing `const EXPRESSReference<>&` , the function cannot access the non-const `operator->()` and with that the non-const `lock()` function. Through that, the `operator=()` is not called if the `weak_ptr` is expired.