### PR TITLE
Creating early binding generator unit tests

### DIFF
--- a/UnitTests/CMakeLists.txt
+++ b/UnitTests/CMakeLists.txt
@@ -36,6 +36,7 @@ endif()
 
 file(GLOB OpenInfraPlatform_UnitTests_Source *.cpp)
 
+add_subdirectory(Generator)
 add_subdirectory(Schemas)
 
 

--- a/UnitTests/Generator/CMakeLists.txt
+++ b/UnitTests/Generator/CMakeLists.txt
@@ -1,0 +1,26 @@
+#
+#    Copyright (c) 2020 Technical University of Munich
+#    Chair of Computational Modeling and Simulation.
+#
+#    TUM Open Infra Platform is free software; you can redistribute it and/or modify
+#    it under the terms of the GNU General Public License Version 3
+#    as published by the Free Software Foundation.
+#
+#    TUM Open Infra Platform is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+#    GNU General Public License for more details.
+#
+#    You should have received a copy of the GNU General Public License
+#    along with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+
+include(CreateUnitTests)
+
+# get all subdirectories (that is, unit tests)
+SUBDIRLIST(SUBDIRS ${CMAKE_CURRENT_LIST_DIR})
+
+# add to the solution
+FOREACH(subdir ${SUBDIRS})
+  ADD_SUBDIRECTORY(${subdir})
+ENDFOREACH()

--- a/UnitTests/Generator/schema_UT_v1/CMakeLists.txt
+++ b/UnitTests/Generator/schema_UT_v1/CMakeLists.txt
@@ -1,0 +1,20 @@
+#
+#    Copyright (c) 2020 Technical University of Munich
+#    Chair of Computational Modeling and Simulation.
+#
+#    TUM Open Infra Platform is free software; you can redistribute it and/or modify
+#    it under the terms of the GNU General Public License Version 3
+#    as published by the Free Software Foundation.
+#
+#    TUM Open Infra Platform is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+#    GNU General Public License for more details.
+#
+#    You should have received a copy of the GNU General Public License
+#    along with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+
+include(CreateUnitTests)
+
+CreateGeneratorUnitTest(schema_UT_v1)

--- a/UnitTests/Generator/schema_UT_v1/Data/schema_UT_v1.exp
+++ b/UnitTests/Generator/schema_UT_v1/Data/schema_UT_v1.exp
@@ -1,0 +1,214 @@
+
+SCHEMA schema_UT_v1;
+
+(* IFC2x3 taken as basis *)
+
+TYPE IfcInteger = INTEGER;
+END_TYPE;
+TYPE IfcLabel = STRING;
+END_TYPE;
+TYPE IfcLengthMeasure = REAL;
+END_TYPE;
+TYPE IfcLogical = LOGICAL;
+END_TYPE;
+TYPE IfcParameterValue = REAL;
+END_TYPE;
+TYPE IfcReal = REAL;
+END_TYPE;
+
+TYPE IfcDimensionCount = INTEGER;
+ WHERE
+	WR1 : { 0 < SELF <= 3 };
+END_TYPE;
+
+TYPE IfcBSplineCurveForm = ENUMERATION OF
+	(POLYLINE_FORM
+	,CIRCULAR_ARC
+	,HYPERBOLIC_ARC
+	,UNSPECIFIED);
+END_TYPE;
+
+TYPE IfcGeometricSetSelect = SELECT
+	(IfcPoint
+	,IfcCurve);
+END_TYPE;
+
+TYPE IfcMeasureValue = SELECT
+	(IfcLengthMeasure
+	,IfcParameterValue);
+END_TYPE;
+
+TYPE IfcTrimmingSelect = SELECT
+	(IfcCartesianPoint
+	,IfcParameterValue);
+END_TYPE;
+
+ENTITY IfcBSplineCurve
+ ABSTRACT SUPERTYPE OF (ONEOF
+	(IfcBezierCurve))
+ SUBTYPE OF (IfcCurve);
+	Degree : INTEGER;
+	ControlPointsList : LIST [2:?] OF IfcCartesianPoint;
+	CurveForm : IfcBSplineCurveForm;
+	ClosedCurve : LOGICAL;
+	SelfIntersect : LOGICAL;
+ DERIVE
+	ControlPoints : ARRAY [0:255] OF IfcCartesianPoint := IfcListToArray(ControlPointsList,0,UpperIndexOnControlPoints);
+	UpperIndexOnControlPoints : INTEGER := (SIZEOF(ControlPointsList) - 1);
+ WHERE
+	WR41 : SIZEOF(QUERY(Temp <* ControlPointsList |
+               Temp.Dim <> ControlPointsList[1].Dim))
+             = 0;
+END_ENTITY;
+
+ENTITY IfcBezierCurve
+ SUBTYPE OF (IfcBSplineCurve);
+	WeightsData : LIST [2:?] OF REAL;
+ DERIVE
+	Weights : ARRAY [0:255] OF REAL := IfcListToArray(WeightsData,0,SELF\IfcBSplineCurve.UpperIndexOnControlPoints);
+ WHERE
+	WR1 : SIZEOF(WeightsData) = SIZEOF(SELF\IfcBSplineCurve.ControlPointsList);
+	WR2 : IfcCurveWeightsPositive(SELF);
+END_ENTITY;
+
+ENTITY IfcCartesianPoint
+ SUBTYPE OF (IfcPoint);
+	Coordinates : LIST [1:3] OF IfcLengthMeasure;
+ DERIVE
+	Dim : IfcDimensionCount := HIINDEX(Coordinates);
+ WHERE
+	WR1 : HIINDEX(Coordinates) >= 2;
+END_ENTITY;
+
+ENTITY IfcCurve
+ ABSTRACT SUPERTYPE OF (ONEOF
+	(IfcBSplineCurve
+	,IfcPolyline
+	,IfcLine))
+ SUBTYPE OF (IfcGeometricRepresentationItem);
+ DERIVE
+	Dim : IfcDimensionCount := IfcCurveDim(SELF);
+END_ENTITY;
+
+ENTITY IfcDirection
+ SUBTYPE OF (IfcGeometricRepresentationItem);
+	DirectionRatios : LIST [2:3] OF REAL;
+ DERIVE
+	Dim : IfcDimensionCount := HIINDEX(DirectionRatios);
+END_ENTITY;
+
+ENTITY IfcGeometricRepresentationItem
+ ABSTRACT SUPERTYPE OF (ONEOF
+	(IfcCurve
+	,IfcDirection
+	,IfcGeometricSet
+	,IfcPoint
+	,IfcVector));
+END_ENTITY;
+
+ENTITY IfcGeometricSet
+ SUBTYPE OF (IfcGeometricRepresentationItem);
+	Elements : SET [1:?] OF IfcGeometricSetSelect;
+ DERIVE
+	Dim : IfcDimensionCount := Elements[1].Dim;
+ WHERE
+	WR21 : SIZEOF(QUERY(Temp <* Elements |
+               Temp.Dim <> Elements[1].Dim))
+             = 0;
+END_ENTITY;
+
+ENTITY IfcLine
+ SUBTYPE OF (IfcCurve);
+	Pnt : IfcCartesianPoint;
+	Dir : IfcVector;
+ WHERE
+	WR1 : Dir.Dim = Pnt.Dim;
+END_ENTITY;
+
+ENTITY IfcPoint
+ ABSTRACT SUPERTYPE OF (ONEOF
+	(IfcCartesianPoint
+	,IfcPointOnCurve))
+ SUBTYPE OF (IfcGeometricRepresentationItem);
+END_ENTITY;
+
+ENTITY IfcPointOnCurve
+ SUBTYPE OF (IfcPoint);
+	BasisCurve : IfcCurve;
+	PointParameter : IfcParameterValue;
+ DERIVE
+	Dim : IfcDimensionCount := BasisCurve.Dim;
+END_ENTITY;
+
+ENTITY IfcPolyline
+ SUBTYPE OF (IfcCurve);
+	Points : LIST [2:?] OF IfcCartesianPoint;
+ WHERE
+	WR41 : SIZEOF(QUERY(Temp <* Points | Temp.Dim <> Points[1].Dim)) = 0;
+END_ENTITY;
+
+ENTITY IfcVector
+ SUBTYPE OF (IfcGeometricRepresentationItem);
+	Orientation : IfcDirection;
+	Magnitude : IfcLengthMeasure;
+ DERIVE
+	Dim : IfcDimensionCount := Orientation.Dim;
+ WHERE
+	WR1 : Magnitude >= 0.0;
+END_ENTITY;
+
+
+
+FUNCTION IfcListToArray
+(Lis : LIST [0:?] OF GENERIC : T;
+       Low,U : INTEGER) : ARRAY OF GENERIC : T;
+   LOCAL
+     N   : INTEGER;
+     Res : ARRAY [Low:U] OF GENERIC : T;
+   END_LOCAL;
+      
+   N := SIZEOF(Lis);
+   IF (N <> (U-Low +1)) THEN
+     RETURN(?);
+   ELSE
+     Res := [Lis[1] : N];
+     REPEAT i := 2 TO N;
+       Res[Low+i-1] := Lis[i];
+     END_REPEAT;
+     RETURN(Res);
+   END_IF;
+END_FUNCTION;
+
+FUNCTION IfcCurveWeightsPositive
+	(B: IfcRationalBezierCurve)
+	: BOOLEAN;
+     LOCAL
+       Result : BOOLEAN := TRUE;
+     END_LOCAL;
+  
+     REPEAT i := 0 TO B.UpperIndexOnControlPoints;
+       IF B.Weights[i] <= 0.0  THEN
+         Result := FALSE;
+         RETURN(Result);
+       END_IF;
+     END_REPEAT;
+     RETURN(Result);
+END_FUNCTION;
+
+FUNCTION IfcCurveDim
+	(Curve : IfcCurve)
+	: IfcDimensionCount;
+  
+    IF ('schema_UT_v1.IFCLINE' IN TYPEOF(Curve))
+      THEN RETURN(Curve\IfcLine.Pnt.Dim);
+    END_IF;
+    IF ('schema_UT_v1.IFCPOLYLINE' IN TYPEOF(Curve))
+      THEN RETURN(Curve\IfcPolyline.Points[1].Dim);
+    END_IF;
+    IF ('schema_UT_v1.IFCBSPLINECURVE' IN TYPEOF(Curve))
+      THEN RETURN(Curve\IfcBSplineCurve.ControlPointsList[1].Dim);
+    END_IF;
+  RETURN (?);
+END_FUNCTION;
+
+END_SCHEMA;

--- a/UnitTests/Generator/schema_UT_v1/src/schema_UT_v1.cpp
+++ b/UnitTests/Generator/schema_UT_v1/src/schema_UT_v1.cpp
@@ -1,0 +1,62 @@
+/*
+    Copyright (c) 2020 Technical University of Munich
+    Chair of Computational Modeling and Simulation.
+
+    TUM Open Infra Platform is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License Version 3
+    as published by the Free Software Foundation.
+
+    TUM Open Infra Platform is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program. If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include <gtest/gtest.h>
+#include <gmock/gmock.h>
+
+#include "boost\filesystem.hpp"
+
+#include <namespace.h>
+
+using namespace testing;
+
+class Schema_UT_v1_Test : public Test {
+    protected:
+    virtual void SetUp() override {
+
+    }
+
+    virtual void TearDown() override {
+
+    }
+
+	// see https://stackoverflow.com/questions/2802188/file-count-in-a-directory-using-c
+	size_t getNumberOfFilesInFolder(const std::string& directoryPath, const bool countDirectoriesAsWell)
+	{
+		if (countDirectoriesAsWell)
+			return std::distance(boost::filesystem::directory_iterator(directoryPath), boost::filesystem::directory_iterator());
+		else
+		{
+			size_t i = 0;
+			for (auto file : boost::filesystem::directory_iterator(directoryPath))
+				if (!boost::filesystem::is_directory(file))
+					i++;
+			return i;
+		}
+	}
+
+    const std::string filepathGenerated = "UnitTests/Generator/schema_UT_v1/Generated/src";
+
+};
+
+TEST_F(Schema_UT_v1_Test, AllFilesAreGenerated) {
+	EXPECT_THAT(getNumberOfFilesInFolder(filepathGenerated, true), Eq(9));
+	EXPECT_THAT(getNumberOfFilesInFolder(filepathGenerated, false), Eq(6));
+	EXPECT_THAT(getNumberOfFilesInFolder(filepathGenerated + "/entity", false), Eq(24));
+	EXPECT_THAT(getNumberOfFilesInFolder(filepathGenerated + "/reader", false), Eq(2));
+	EXPECT_THAT(getNumberOfFilesInFolder(filepathGenerated + "/type", false), Eq(22));
+}

--- a/UnitTests/Generator/schema_UT_v2/CMakeLists.txt
+++ b/UnitTests/Generator/schema_UT_v2/CMakeLists.txt
@@ -1,0 +1,20 @@
+#
+#    Copyright (c) 2020 Technical University of Munich
+#    Chair of Computational Modeling and Simulation.
+#
+#    TUM Open Infra Platform is free software; you can redistribute it and/or modify
+#    it under the terms of the GNU General Public License Version 3
+#    as published by the Free Software Foundation.
+#
+#    TUM Open Infra Platform is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+#    GNU General Public License for more details.
+#
+#    You should have received a copy of the GNU General Public License
+#    along with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+
+include(CreateUnitTests)
+
+CreateGeneratorUnitTest(schema_UT_v2)

--- a/UnitTests/Generator/schema_UT_v2/Data/schema_UT_v2.exp
+++ b/UnitTests/Generator/schema_UT_v2/Data/schema_UT_v2.exp
@@ -1,0 +1,296 @@
+
+SCHEMA schema_UT_v2;
+
+(* IFC4 taken as basis *)
+
+TYPE IfcInteger = INTEGER;
+END_TYPE;
+TYPE IfcLabel = STRING(255);
+END_TYPE;
+TYPE IfcLengthMeasure = REAL;
+END_TYPE;
+TYPE IfcLogical = LOGICAL;
+END_TYPE;
+TYPE IfcParameterValue = REAL;
+END_TYPE;
+TYPE IfcReal = REAL;
+END_TYPE;
+
+TYPE IfcDimensionCount = INTEGER;
+ WHERE
+	WR1 : { 0 < SELF <= 3 };
+END_TYPE;
+
+TYPE IfcBSplineCurveForm = ENUMERATION OF
+    (POLYLINE_FORM
+    ,CIRCULAR_ARC
+    ,ELLIPTIC_ARC
+    ,PARABOLIC_ARC
+    ,HYPERBOLIC_ARC
+    ,UNSPECIFIED);
+END_TYPE;
+
+TYPE IfcGeometricSetSelect = SELECT
+	(IfcPoint
+	,IfcCurve);
+END_TYPE;
+
+TYPE IfcKnotType = ENUMERATION OF
+    (UNIFORM_KNOTS
+    ,QUASI_UNIFORM_KNOTS
+    ,PIECEWISE_BEZIER_KNOTS
+    ,UNSPECIFIED);
+END_TYPE;
+
+TYPE IfcMeasureValue = SELECT
+	(IfcLengthMeasure
+	,IfcParameterValue);
+END_TYPE;
+
+TYPE IfcTrimmingSelect = SELECT
+	(IfcCartesianPoint
+	,IfcParameterValue);
+END_TYPE;
+
+ENTITY IfcBoundedCurve
+ ABSTRACT SUPERTYPE OF (ONEOF
+    (IfcBSplineCurve
+    ,IfcPolyline))
+ SUBTYPE OF (IfcCurve);
+END_ENTITY;
+
+ENTITY IfcBSplineCurve
+ ABSTRACT SUPERTYPE OF (ONEOF
+	(IfcBezierCurve))
+ SUBTYPE OF (IfcBoundedCurve);
+	Degree : INTEGER;
+	ControlPointsList : LIST [2:?] OF IfcCartesianPoint;
+	CurveForm : IfcBSplineCurveForm;
+	ClosedCurve : LOGICAL;
+	SelfIntersect : LOGICAL;
+ DERIVE
+    UpperIndexOnControlPoints : INTEGER := (SIZEOF(ControlPointsList) - 1);
+	ControlPoints : ARRAY [0:UpperIndexOnControlPoints] OF IfcCartesianPoint := IfcListToArray(ControlPointsList,0,UpperIndexOnControlPoints);
+ WHERE
+    SameDim : SIZEOF(QUERY(Temp <* ControlPointsList |
+                  Temp.Dim <> ControlPointsList[1].Dim)) = 0;
+END_ENTITY;
+
+ENTITY IfcBSplineCurveWithKnots
+ SUPERTYPE OF (ONEOF
+    (IfcRationalBSplineCurveWithKnots))
+ SUBTYPE OF (IfcBSplineCurve);
+    KnotMultiplicities : LIST [2:?] OF INTEGER;
+    Knots : LIST [2:?] OF IfcParameterValue;
+    KnotSpec : IfcKnotType;
+ DERIVE
+    UpperIndexOnKnots : INTEGER := SIZEOF(Knots);
+ WHERE
+    ConsistentBSpline : IfcConstraintsParamBSpline(Degree, UpperIndexOnKnots, UpperIndexOnControlPoints, KnotMultiplicities, Knots);
+    CorrespondingKnotLists : SIZEOF(KnotMultiplicities) = UpperIndexOnKnots;
+END_ENTITY;
+
+ENTITY IfcCartesianPoint
+ SUBTYPE OF (IfcPoint);
+	Coordinates : LIST [1:3] OF IfcLengthMeasure;
+ DERIVE
+	Dim : IfcDimensionCount := HIINDEX(Coordinates);
+ WHERE
+	WR1 : HIINDEX(Coordinates) >= 2;
+END_ENTITY;
+
+ENTITY IfcCurve
+ ABSTRACT SUPERTYPE OF (ONEOF
+    (IfcBoundedCurve
+    ,IfcLine))
+ SUBTYPE OF (IfcGeometricRepresentationItem);
+ DERIVE
+	Dim : IfcDimensionCount := IfcCurveDim(SELF);
+END_ENTITY;
+
+ENTITY IfcDirection
+ SUBTYPE OF (IfcGeometricRepresentationItem);
+	DirectionRatios : LIST [2:3] OF REAL;
+ DERIVE
+	Dim : IfcDimensionCount := HIINDEX(DirectionRatios);
+ WHERE
+    MagnitudeGreaterZero : SIZEOF(QUERY(Tmp <* DirectionRatios | Tmp <> 0.0)) > 0;
+END_ENTITY;
+
+ENTITY IfcGeometricRepresentationItem
+ ABSTRACT SUPERTYPE OF (ONEOF
+	(IfcCurve
+	,IfcDirection
+	,IfcGeometricSet
+	,IfcPoint
+	,IfcVector));
+END_ENTITY;
+
+ENTITY IfcGeometricSet
+ SUBTYPE OF (IfcGeometricRepresentationItem);
+	Elements : SET [1:?] OF IfcGeometricSetSelect;
+ DERIVE
+	Dim : IfcDimensionCount := Elements[1].Dim;
+ WHERE
+    ConsistentDim : SIZEOF(QUERY(Temp <* Elements |
+                        Temp.Dim <> Elements[1].Dim))
+                      = 0;
+END_ENTITY;
+
+ENTITY IfcLine
+ SUBTYPE OF (IfcCurve);
+	Pnt : IfcCartesianPoint;
+	Dir : IfcVector;
+ WHERE
+	SameDim : Dir.Dim = Pnt.Dim;
+END_ENTITY;
+
+ENTITY IfcPoint
+ ABSTRACT SUPERTYPE OF (ONEOF
+	(IfcCartesianPoint
+	,IfcPointOnCurve))
+ SUBTYPE OF (IfcGeometricRepresentationItem);
+END_ENTITY;
+
+ENTITY IfcPointOnCurve
+ SUBTYPE OF (IfcPoint);
+	BasisCurve : IfcCurve;
+	PointParameter : IfcParameterValue;
+ DERIVE
+	Dim : IfcDimensionCount := BasisCurve.Dim;
+END_ENTITY;
+
+ENTITY IfcPolyline
+ SUBTYPE OF (IfcBoundedCurve);
+	Points : LIST [2:?] OF IfcCartesianPoint;
+ WHERE
+	SameDim : SIZEOF(QUERY(Temp <* Points | Temp.Dim <> Points[1].Dim)) = 0;
+END_ENTITY;
+
+ENTITY IfcRationalBSplineCurveWithKnots
+ SUBTYPE OF (IfcBSplineCurveWithKnots);
+    WeightsData : LIST [2:?] OF REAL;
+ DERIVE
+    Weights : ARRAY [0:UpperIndexOnControlPoints] OF REAL := IfcListToArray(WeightsData,0,SELF\IfcBSplineCurve.UpperIndexOnControlPoints);
+ WHERE
+    SameNumOfWeightsAndPoints : SIZEOF(WeightsData) = SIZEOF(SELF\IfcBSplineCurve.ControlPointsList);
+    WeightsGreaterZero : IfcCurveWeightsPositive(SELF);
+END_ENTITY;
+
+ENTITY IfcVector
+ SUBTYPE OF (IfcGeometricRepresentationItem);
+	Orientation : IfcDirection;
+	Magnitude : IfcLengthMeasure;
+ DERIVE
+	Dim : IfcDimensionCount := Orientation.Dim;
+ WHERE
+	MagGreaterOrEqualZero : Magnitude >= 0.0;
+END_ENTITY;
+
+
+
+FUNCTION IfcListToArray
+(Lis : LIST [0:?] OF GENERIC : T;
+       Low,U : INTEGER) : ARRAY OF GENERIC : T;
+   LOCAL
+     N   : INTEGER;
+     Res : ARRAY [Low:U] OF GENERIC : T;
+   END_LOCAL;
+      
+   N := SIZEOF(Lis);
+   IF (N <> (U-Low +1)) THEN
+     RETURN(?);
+   ELSE
+     Res := [Lis[1] : N];
+     REPEAT i := 2 TO N;
+       Res[Low+i-1] := Lis[i];
+     END_REPEAT;
+     RETURN(Res);
+   END_IF;
+END_FUNCTION;
+
+FUNCTION IfcCurveWeightsPositive
+	(B: IfcRationalBSplineCurveWithKnots)
+	: BOOLEAN;
+     LOCAL
+       Result : BOOLEAN := TRUE;
+     END_LOCAL;
+  
+     REPEAT i := 0 TO B.UpperIndexOnControlPoints;
+       IF B.Weights[i] <= 0.0  THEN
+         Result := FALSE;
+         RETURN(Result);
+       END_IF;
+     END_REPEAT;
+     RETURN(Result);
+END_FUNCTION;
+
+FUNCTION IfcCurveDim
+	(Curve : IfcCurve)
+	: IfcDimensionCount;
+  
+    IF ('schema_UT_v2.IFCLINE' IN TYPEOF(Curve))
+      THEN RETURN(Curve\IfcLine.Pnt.Dim);
+    END_IF;
+    IF ('schema_UT_v2.IFCPOLYLINE' IN TYPEOF(Curve))
+      THEN RETURN(Curve\IfcPolyline.Points[1].Dim);
+    END_IF;
+    IF ('schema_UT_v2.IFCBSPLINECURVE' IN TYPEOF(Curve))
+      THEN RETURN(Curve\IfcBSplineCurve.ControlPointsList[1].Dim);
+    END_IF;
+  RETURN (?);
+END_FUNCTION;
+
+
+FUNCTION IfcConstraintsParamBSpline
+( Degree, UpKnots, UpCp : INTEGER;
+  KnotMult : LIST OF INTEGER;
+  Knots : LIST OF IfcParameterValue ) 
+: BOOLEAN;
+
+
+  LOCAL
+    Result : BOOLEAN := TRUE;
+    K, Sum : INTEGER;
+  END_LOCAL;
+
+  (* Find sum of knot multiplicities. *)
+  Sum := KnotMult[1];
+  REPEAT i := 2 TO UpKnots;
+    Sum := Sum + KnotMult[i];
+  END_REPEAT;
+
+  (* Check limits holding for all B-spline parametrisations *)
+  IF (Degree < 1) OR (UpKnots < 2) OR (UpCp < Degree) OR
+    (Sum <> (Degree + UpCp + 2)) THEN
+    Result := FALSE;
+    RETURN(Result);
+  END_IF;
+
+  K := KnotMult[1];
+  IF (K < 1) OR (K > Degree + 1) THEN
+    Result := FALSE;
+    RETURN(Result);
+  END_IF;
+
+  REPEAT i := 2 TO UpKnots;
+    IF (KnotMult[i] < 1) OR (Knots[i] <= Knots[i-1]) THEN
+      Result := FALSE;
+      RETURN(Result);
+    END_IF;
+    K := KnotMult[i];
+    IF (i < UpKnots) AND (K > Degree) THEN
+      Result := FALSE;
+      RETURN(Result);
+    END_IF;
+    IF (i = UpKnots) AND (K > Degree + 1) THEN
+      Result := FALSE;
+      RETURN(Result);
+    END_IF;
+  END_REPEAT;
+
+  RETURN(result);
+END_FUNCTION;
+
+
+END_SCHEMA;

--- a/UnitTests/Generator/schema_UT_v2/src/schema_UT_v2.cpp
+++ b/UnitTests/Generator/schema_UT_v2/src/schema_UT_v2.cpp
@@ -1,0 +1,62 @@
+/*
+    Copyright (c) 2020 Technical University of Munich
+    Chair of Computational Modeling and Simulation.
+
+    TUM Open Infra Platform is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License Version 3
+    as published by the Free Software Foundation.
+
+    TUM Open Infra Platform is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program. If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include <gtest/gtest.h>
+#include <gmock/gmock.h>
+
+#include "boost\filesystem.hpp"
+
+#include <namespace.h>
+
+using namespace testing;
+
+class Schema_UT_v2_Test : public Test {
+    protected:
+    virtual void SetUp() override {
+
+    }
+
+    virtual void TearDown() override {
+
+    }
+
+	// see https://stackoverflow.com/questions/2802188/file-count-in-a-directory-using-c
+	size_t getNumberOfFilesInFolder(const std::string& directoryPath, const bool countDirectoriesAsWell)
+	{
+		if (countDirectoriesAsWell)
+			return std::distance(boost::filesystem::directory_iterator(directoryPath), boost::filesystem::directory_iterator());
+		else
+		{
+			size_t i = 0;
+			for (auto file : boost::filesystem::directory_iterator(directoryPath))
+				if (!boost::filesystem::is_directory(file))
+					i++;
+			return i;
+		}
+	}
+
+    const std::string filepathGenerated = "UnitTests/Generator/schema_UT_v2/Generated/src";
+
+};
+
+TEST_F(Schema_UT_v2_Test, AllFilesAreGenerated) {
+	EXPECT_THAT(getNumberOfFilesInFolder(filepathGenerated, true), Eq(9));
+	EXPECT_THAT(getNumberOfFilesInFolder(filepathGenerated, false), Eq(6));
+	EXPECT_THAT(getNumberOfFilesInFolder(filepathGenerated + "/entity", false), Eq(28));
+	EXPECT_THAT(getNumberOfFilesInFolder(filepathGenerated + "/reader", false), Eq(2));
+	EXPECT_THAT(getNumberOfFilesInFolder(filepathGenerated + "/type", false), Eq(24));
+}

--- a/UnitTests/Generator/schema_UT_v3/CMakeLists.txt
+++ b/UnitTests/Generator/schema_UT_v3/CMakeLists.txt
@@ -1,0 +1,20 @@
+#
+#    Copyright (c) 2020 Technical University of Munich
+#    Chair of Computational Modeling and Simulation.
+#
+#    TUM Open Infra Platform is free software; you can redistribute it and/or modify
+#    it under the terms of the GNU General Public License Version 3
+#    as published by the Free Software Foundation.
+#
+#    TUM Open Infra Platform is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+#    GNU General Public License for more details.
+#
+#    You should have received a copy of the GNU General Public License
+#    along with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+
+include(CreateUnitTests)
+
+CreateGeneratorUnitTest(schema_UT_v3)

--- a/UnitTests/Generator/schema_UT_v3/Data/schema_UT_v3.exp
+++ b/UnitTests/Generator/schema_UT_v3/Data/schema_UT_v3.exp
@@ -1,0 +1,309 @@
+
+SCHEMA schema_UT_v3;
+
+(* IFC4x3 taken as basis *)
+
+TYPE IfcInteger = INTEGER;
+END_TYPE;
+TYPE IfcLabel = STRING(255);
+END_TYPE;
+TYPE IfcLengthMeasure = REAL;
+END_TYPE;
+TYPE IfcLogical = LOGICAL;
+END_TYPE;
+TYPE IfcParameterValue = REAL;
+END_TYPE;
+TYPE IfcReal = REAL;
+END_TYPE;
+
+TYPE IfcDimensionCount = INTEGER;
+ WHERE
+	WR1 : { 0 < SELF <= 3 };
+END_TYPE;
+
+TYPE IfcBSplineCurveForm = ENUMERATION OF
+    (POLYLINE_FORM
+    ,CIRCULAR_ARC
+    ,ELLIPTIC_ARC
+    ,PARABOLIC_ARC
+    ,HYPERBOLIC_ARC
+    ,UNSPECIFIED);
+END_TYPE;
+
+TYPE IfcGeometricSetSelect = SELECT
+	(IfcPoint
+	,IfcCurve);
+END_TYPE;
+
+TYPE IfcKnotType = ENUMERATION OF
+    (UNIFORM_KNOTS
+    ,QUASI_UNIFORM_KNOTS
+    ,PIECEWISE_BEZIER_KNOTS
+    ,UNSPECIFIED);
+END_TYPE;
+
+TYPE IfcMeasureValue = SELECT
+	(IfcLengthMeasure
+	,IfcParameterValue);
+END_TYPE;
+
+TYPE IfcTrimmingSelect = SELECT
+	(IfcCartesianPoint
+	,IfcParameterValue);
+END_TYPE;
+
+ENTITY IfcAlignment2DHorizontal
+ SUBTYPE OF (IfcGeometricRepresentationItem);
+ INVERSE
+    ToAlignmentCurve : SET [1:?] OF IfcAlignmentCurve FOR Horizontal;
+END_ENTITY;
+
+ENTITY IfcAlignment2DVertical
+ SUBTYPE OF (IfcGeometricRepresentationItem);
+ INVERSE
+    ToAlignmentCurve : SET [1:1] OF IfcAlignmentCurve FOR Vertical;
+END_ENTITY;
+
+ENTITY IfcAlignmentCurve
+ SUBTYPE OF (IfcBoundedCurve);
+    Horizontal : IfcAlignment2DHorizontal;
+    Vertical : OPTIONAL IfcAlignment2DVertical;
+    Tag : OPTIONAL IfcLabel;
+END_ENTITY;
+
+ENTITY IfcBoundedCurve
+ ABSTRACT SUPERTYPE OF (ONEOF
+    (IfcAlignmentCurve
+    ,IfcBSplineCurve
+    ,IfcPolyline))
+ SUBTYPE OF (IfcCurve);
+END_ENTITY;
+
+ENTITY IfcBSplineCurve
+ ABSTRACT SUPERTYPE OF (ONEOF
+    (IfcBSplineCurveWithKnots))
+ SUBTYPE OF (IfcBoundedCurve);
+    Degree : IfcInteger;
+    ControlPointsList : LIST [2:?] OF IfcCartesianPoint;
+    CurveForm : IfcBSplineCurveForm;
+    ClosedCurve : IfcLogical;
+    SelfIntersect : IfcLogical;
+ DERIVE
+    UpperIndexOnControlPoints : IfcInteger := (SIZEOF(ControlPointsList) - 1);
+    ControlPoints : ARRAY [0:UpperIndexOnControlPoints] OF IfcCartesianPoint := IfcListToArray(ControlPointsList,0,UpperIndexOnControlPoints);
+ WHERE
+    SameDim : SIZEOF(QUERY(Temp <* ControlPointsList |
+  Temp.Dim <> ControlPointsList[1].Dim)) = 0;
+END_ENTITY;
+
+ENTITY IfcBSplineCurveWithKnots
+ SUPERTYPE OF (ONEOF
+    (IfcRationalBSplineCurveWithKnots))
+ SUBTYPE OF (IfcBSplineCurve);
+    KnotMultiplicities : LIST [2:?] OF IfcInteger;
+    Knots : LIST [2:?] OF IfcParameterValue;
+    KnotSpec : IfcKnotType;
+ DERIVE
+    UpperIndexOnKnots : IfcInteger := SIZEOF(Knots);
+ WHERE
+    ConsistentBSpline : IfcConstraintsParamBSpline(Degree, UpperIndexOnKnots,
+UpperIndexOnControlPoints, KnotMultiplicities, Knots);
+    CorrespondingKnotLists : SIZEOF(KnotMultiplicities) = UpperIndexOnKnots;
+END_ENTITY;
+
+ENTITY IfcCartesianPoint
+ SUBTYPE OF (IfcPoint);
+	Coordinates : LIST [1:3] OF IfcLengthMeasure;
+ DERIVE
+	Dim : IfcDimensionCount := HIINDEX(Coordinates);
+ WHERE
+    CP2Dor3D : HIINDEX(Coordinates) >= 2;
+END_ENTITY;
+
+ENTITY IfcCurve
+ ABSTRACT SUPERTYPE OF (ONEOF
+    (IfcBoundedCurve
+    ,IfcLine))
+ SUBTYPE OF (IfcGeometricRepresentationItem);
+ DERIVE
+	Dim : IfcDimensionCount := IfcCurveDim(SELF);
+END_ENTITY;
+
+ENTITY IfcDirection
+ SUBTYPE OF (IfcGeometricRepresentationItem);
+	DirectionRatios : LIST [2:3] OF REAL;
+ DERIVE
+	Dim : IfcDimensionCount := HIINDEX(DirectionRatios);
+ WHERE
+    MagnitudeGreaterZero : SIZEOF(QUERY(Tmp <* DirectionRatios | Tmp <> 0.0)) > 0;
+END_ENTITY;
+
+ENTITY IfcGeometricRepresentationItem
+ ABSTRACT SUPERTYPE OF (ONEOF
+    (IfcAlignment2DHorizontal
+    ,IfcAlignment2DVertical
+	,IfcCurve
+	,IfcDirection
+	,IfcGeometricSet
+	,IfcPoint
+	,IfcVector));
+END_ENTITY;
+
+ENTITY IfcGeometricSet
+ SUBTYPE OF (IfcGeometricRepresentationItem);
+	Elements : SET [1:?] OF IfcGeometricSetSelect;
+ DERIVE
+	Dim : IfcDimensionCount := Elements[1].Dim;
+ WHERE
+    ConsistentDim : SIZEOF(QUERY(Temp <* Elements |
+  Temp.Dim <> Elements[1].Dim)) = 0;
+END_ENTITY;
+
+ENTITY IfcLine
+ SUBTYPE OF (IfcCurve);
+	Pnt : IfcCartesianPoint;
+	Dir : IfcVector;
+ WHERE
+	SameDim : Dir.Dim = Pnt.Dim;
+END_ENTITY;
+
+ENTITY IfcPoint
+ ABSTRACT SUPERTYPE OF (ONEOF
+	(IfcCartesianPoint
+	,IfcPointOnCurve))
+ SUBTYPE OF (IfcGeometricRepresentationItem);
+END_ENTITY;
+
+ENTITY IfcPointOnCurve
+ SUBTYPE OF (IfcPoint);
+	BasisCurve : IfcCurve;
+	PointParameter : IfcParameterValue;
+ DERIVE
+	Dim : IfcDimensionCount := BasisCurve.Dim;
+END_ENTITY;
+
+ENTITY IfcPolyline
+ SUBTYPE OF (IfcBoundedCurve);
+	Points : LIST [2:?] OF IfcCartesianPoint;
+ WHERE
+	SameDim : SIZEOF(QUERY(Temp <* Points | Temp.Dim <> Points[1].Dim)) = 0;
+END_ENTITY;
+
+ENTITY IfcVector
+ SUBTYPE OF (IfcGeometricRepresentationItem);
+	Orientation : IfcDirection;
+	Magnitude : IfcLengthMeasure;
+ DERIVE
+	Dim : IfcDimensionCount := Orientation.Dim;
+ WHERE
+	MagGreaterOrEqualZero : Magnitude >= 0.0;
+END_ENTITY;
+
+
+
+FUNCTION IfcListToArray
+(Lis : LIST [0:?] OF GENERIC : T;
+       Low,U : INTEGER) : ARRAY OF GENERIC : T;
+   LOCAL
+     N   : INTEGER;
+     Res : ARRAY [Low:U] OF GENERIC : T;
+   END_LOCAL;
+      
+   N := SIZEOF(Lis);
+   IF (N <> (U-Low +1)) THEN
+     RETURN(?);
+   ELSE
+     Res := [Lis[1] : N];
+     REPEAT i := 2 TO N;
+       Res[Low+i-1] := Lis[i];
+     END_REPEAT;
+     RETURN(Res);
+   END_IF;
+END_FUNCTION;
+
+FUNCTION IfcCurveWeightsPositive
+	(B: IfcRationalBSplineCurveWithKnots)
+	: BOOLEAN;
+     LOCAL
+       Result : BOOLEAN := TRUE;
+     END_LOCAL;
+  
+     REPEAT i := 0 TO B.UpperIndexOnControlPoints;
+       IF B.Weights[i] <= 0.0  THEN
+         Result := FALSE;
+         RETURN(Result);
+       END_IF;
+     END_REPEAT;
+     RETURN(Result);
+END_FUNCTION;
+
+FUNCTION IfcCurveDim
+	(Curve : IfcCurve)
+	: IfcDimensionCount;
+  
+    IF ('schema_UT_v3.IFCLINE' IN TYPEOF(Curve))
+      THEN RETURN(Curve\IfcLine.Pnt.Dim);
+    END_IF;
+    IF ('schema_UT_v3.IFCPOLYLINE' IN TYPEOF(Curve))
+      THEN RETURN(Curve\IfcPolyline.Points[1].Dim);
+    END_IF;
+    IF ('schema_UT_v3.IFCBSPLINECURVE' IN TYPEOF(Curve))
+      THEN RETURN(Curve\IfcBSplineCurve.ControlPointsList[1].Dim);
+    END_IF;
+    IF ('IFC4X3_RC1.IFCALIGNMENTCURVE' IN TYPEOF(Curve))
+      THEN RETURN(3);
+    END_IF;
+  RETURN (?);
+END_FUNCTION;
+
+FUNCTION IfcConstraintsParamBSpline
+( Degree, UpKnots, UpCp : INTEGER;
+  KnotMult : LIST OF INTEGER;
+  Knots : LIST OF IfcParameterValue ) 
+: BOOLEAN;
+
+
+  LOCAL
+    Result : BOOLEAN := TRUE;
+    K, Sum : INTEGER;
+  END_LOCAL;
+
+  (* Find sum of knot multiplicities. *)
+  Sum := KnotMult[1];
+  REPEAT i := 2 TO UpKnots;
+    Sum := Sum + KnotMult[i];
+  END_REPEAT;
+
+  (* Check limits holding for all B-spline parametrisations *)
+  IF (Degree < 1) OR (UpKnots < 2) OR (UpCp < Degree) OR
+    (Sum <> (Degree + UpCp + 2)) THEN
+    Result := FALSE;
+    RETURN(Result);
+  END_IF;
+
+  K := KnotMult[1];
+  IF (K < 1) OR (K > Degree + 1) THEN
+    Result := FALSE;
+    RETURN(Result);
+  END_IF;
+
+  REPEAT i := 2 TO UpKnots;
+    IF (KnotMult[i] < 1) OR (Knots[i] <= Knots[i-1]) THEN
+      Result := FALSE;
+      RETURN(Result);
+    END_IF;
+    K := KnotMult[i];
+    IF (i < UpKnots) AND (K > Degree) THEN
+      Result := FALSE;
+      RETURN(Result);
+    END_IF;
+    IF (i = UpKnots) AND (K > Degree + 1) THEN
+      Result := FALSE;
+      RETURN(Result);
+    END_IF;
+  END_REPEAT;
+
+  RETURN(result);
+END_FUNCTION;
+
+END_SCHEMA;

--- a/UnitTests/Generator/schema_UT_v3/src/schema_UT_v3.cpp
+++ b/UnitTests/Generator/schema_UT_v3/src/schema_UT_v3.cpp
@@ -1,0 +1,62 @@
+/*
+    Copyright (c) 2020 Technical University of Munich
+    Chair of Computational Modeling and Simulation.
+
+    TUM Open Infra Platform is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License Version 3
+    as published by the Free Software Foundation.
+
+    TUM Open Infra Platform is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program. If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include <gtest/gtest.h>
+#include <gmock/gmock.h>
+
+#include "boost\filesystem.hpp"
+
+#include <namespace.h>
+
+using namespace testing;
+
+class Schema_UT_v3_Test : public Test {
+    protected:
+    virtual void SetUp() override {
+
+    }
+
+    virtual void TearDown() override {
+
+    }
+
+	// see https://stackoverflow.com/questions/2802188/file-count-in-a-directory-using-c
+	size_t getNumberOfFilesInFolder(const std::string& directoryPath, const bool countDirectoriesAsWell)
+	{
+		if (countDirectoriesAsWell)
+			return std::distance(boost::filesystem::directory_iterator(directoryPath), boost::filesystem::directory_iterator());
+		else
+		{
+			size_t i = 0;
+			for (auto file : boost::filesystem::directory_iterator(directoryPath))
+				if (!boost::filesystem::is_directory(file))
+					i++;
+			return i;
+		}
+	}
+
+    const std::string filepathGenerated = "UnitTests/Generator/schema_UT_v3/Generated/src";
+
+};
+
+TEST_F(Schema_UT_v3_Test, AllFilesAreGenerated) {
+	EXPECT_THAT(getNumberOfFilesInFolder(filepathGenerated, true), Eq(9));
+	EXPECT_THAT(getNumberOfFilesInFolder(filepathGenerated, false), Eq(6));
+	EXPECT_THAT(getNumberOfFilesInFolder(filepathGenerated + "/entity", false), Eq(32));
+	EXPECT_THAT(getNumberOfFilesInFolder(filepathGenerated + "/reader", false), Eq(2));
+	EXPECT_THAT(getNumberOfFilesInFolder(filepathGenerated + "/type", false), Eq(24));
+}

--- a/UnitTests/main.cpp
+++ b/UnitTests/main.cpp
@@ -29,5 +29,13 @@ int main(int argc, char **argv) {
 		std::cout << "Unit test crashed..." << e.what() << std::endl;
 	}
 
+	if( result )
+	{
+		// only pause for user input if the result is not 0 ( != OK )
+		std::cout << "Observe the results." << std::endl;
+		std::cout << "Press Enter to exit ...";
+		getchar();
+	}
+
 	return result;
 }

--- a/cmake/CreateUnitTests.cmake
+++ b/cmake/CreateUnitTests.cmake
@@ -56,7 +56,7 @@ function(CreateIfcFileUnitTestForSchema test_name schema)
     set(UnitTest_Data_Rel_Path UnitTests/Schemas/${schema}/${test_name}/Data)
 
     add_custom_command(TARGET ${UnitTest_Executable_Name} POST_BUILD
-        COMMENT "Copying resources from '${CMAKE_SOURCE_DIR}/${UnitTest_Data_Rel_Path}' to '${CMAKE_BINARY_DIR}/$<CONFIG>/${UnitTest_Data_Rel_Path}'" VERBATIM
+        COMMAND ${CMAKE_COMMAND} -E echo "Copying resources from '${CMAKE_SOURCE_DIR}/${UnitTest_Data_Rel_Path}' to '${CMAKE_BINARY_DIR}/$<CONFIG>/${UnitTest_Data_Rel_Path}'"
         COMMAND	${CMAKE_COMMAND} -E make_directory ${CMAKE_SOURCE_DIR}/${UnitTest_Data_Rel_Path}
         COMMAND	${CMAKE_COMMAND} -E copy_directory ${CMAKE_SOURCE_DIR}/${UnitTest_Data_Rel_Path} ${CMAKE_BINARY_DIR}/$<CONFIG>/${UnitTest_Data_Rel_Path}
     )
@@ -68,6 +68,69 @@ function(CreateIfcFileVisualUnitTestForSchema test_name schema)
   target_link_libraries(${test_name} PUBLIC OpenInfraPlatform.Rendering)
 endfunction(CreateIfcFileVisualUnitTestForSchema)
 
+
+function(CreateGeneratorUnitTest schema)
+
+    set(UnitTest_Executable_Name UnitTest.${schema})
+    set(UnitTest_Generator_Name Generate.${schema})
+    set(UnitTest_Rel_Path UnitTests/Generator/${schema})
+    set(UnitTest_Binary_Path ${UnitTest_Rel_Path}/Generated)
+    set(UnitTest_Data_Rel_Path ${UnitTest_Rel_Path}/Data)
+
+    # Custom target that generates the early binding library files.
+    add_custom_target(${UnitTest_Generator_Name}
+        COMMAND ${CMAKE_COMMAND} -E make_directory  ${CMAKE_BINARY_DIR}/${UnitTest_Binary_Path}
+        COMMAND ${CMAKE_COMMAND} -E remove_directory  ${CMAKE_BINARY_DIR}/${UnitTest_Binary_Path}/${schema}
+        COMMAND OpenInfraPlatform.ExpressBindingGenerator ${CMAKE_SOURCE_DIR}/${UnitTest_Data_Rel_Path}/${schema}.exp -o ${CMAKE_BINARY_DIR}/${UnitTest_Binary_Path}
+    )
+    set_target_properties(${UnitTest_Generator_Name} PROPERTIES FOLDER "OpenInfraPlatform/UnitTests/Generator/${schema}")
+    add_dependencies(${UnitTest_Generator_Name} OpenInfraPlatform.ExpressBindingGenerator)
+
+    # Executable for gtest
+    file(GLOB OpenInfraPlatform_UnitTests_Generator_${schema} src/*.cpp)
+
+    source_group(UnitTests\\${schema}    FILES ${OpenInfraPlatform_UnitTests_Generator_${schema}})
+    source_group(UnitTests               FILES ${OpenInfraPlatform_UnitTests_Source})
+
+    add_executable(${UnitTest_Executable_Name}
+        ${OpenInfraPlatform_UnitTests_Generator_${schema}}
+        ${OpenInfraPlatform_UnitTests_Source}
+    )
+
+    get_directory_property(PARENT_DIR DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR} PARENT_DIRECTORY)
+
+    target_include_directories(${UnitTest_Executable_Name}
+        PUBLIC
+            ${blue_framework_SOURCE_DIR}/include
+        PRIVATE
+            ${PARENT_DIR}
+    )
+
+    add_dependencies(${UnitTest_Executable_Name} ${UnitTest_Generator_Name})
+    target_link_libraries(${UnitTest_Executable_Name}
+        PUBLIC
+            gmock
+            gtest
+            gtest_main
+    )
+
+    gtest_discover_tests(${UnitTest_Executable_Name})
+
+    set_target_properties(${UnitTest_Executable_Name} PROPERTIES FOLDER "OpenInfraPlatform/UnitTests/Generator/${schema}")
+
+    add_custom_command(TARGET ${UnitTest_Executable_Name} POST_BUILD
+        COMMAND ${CMAKE_COMMAND} -E echo "Copying resources from '${CMAKE_SOURCE_DIR}/${UnitTest_Data_Rel_Path}' to '${CMAKE_BINARY_DIR}/$<CONFIG>/${UnitTest_Data_Rel_Path}'"
+        COMMAND ${CMAKE_COMMAND} -E make_directory ${CMAKE_SOURCE_DIR}/${UnitTest_Data_Rel_Path}
+        COMMAND ${CMAKE_COMMAND} -E copy_directory ${CMAKE_SOURCE_DIR}/${UnitTest_Data_Rel_Path} ${CMAKE_BINARY_DIR}/$<CONFIG>/${UnitTest_Data_Rel_Path}
+    )
+
+    add_custom_command(TARGET ${UnitTest_Executable_Name} POST_BUILD
+        COMMAND ${CMAKE_COMMAND} -E echo "Copying generated from '${CMAKE_BINARY_DIR}/${UnitTest_Binary_Path}/${schema}' to '${CMAKE_BINARY_DIR}/$<CONFIG>/${UnitTest_Binary_Path}'"
+        COMMAND ${CMAKE_COMMAND} -E make_directory ${CMAKE_BINARY_DIR}/${UnitTest_Binary_Path}/${schema}
+        COMMAND ${CMAKE_COMMAND} -E copy_directory ${CMAKE_BINARY_DIR}/${UnitTest_Binary_Path}/${schema} ${CMAKE_BINARY_DIR}/$<CONFIG>/${UnitTest_Binary_Path}
+    )
+
+endfunction(CreateGeneratorUnitTest)
 
 # see https://stackoverflow.com/questions/7787823/cmake-how-to-get-the-name-of-all-subdirectories-of-a-directory
 # get all subdirectories of a directory


### PR DESCRIPTION
Created unit tests given the small schema produced at the start of the great refactor. Now these are incorporated in the Unit Test group and can be used for further development of EarlyBindingGenerator.

Fixes #194 .