### PR TITLE
Only entity attributes

### DIFF
--- a/ExpressBindingGenerator/src/Generator/GeneratorOIP.cpp
+++ b/ExpressBindingGenerator/src/Generator/GeneratorOIP.cpp
@@ -3979,62 +3979,62 @@ void GeneratorOIP::generateEntitySourceFileREFACTORED(const Schema & schema, con
 	auto allAttributes = schema.getAllEntityAttributes(entity);
 	auto attributes = entity.getAttributes();
 
-	//std::set<std::string> typeAttributes, entityAttributes;
+	std::set<std::string> typeAttributes, entityAttributes;
 
-	//for (const auto attr : allAttributes) {
-	//	if (attr.type->getType() == eEntityAttributeParameterType::TypeNamed) {
-	//		if (schema.hasEntity(attr.type->toString())) {
-	//			entityAttributes.insert(attr.type->toString());
-	//		}
-	//		if (schema.hasType(attr.type->toString())) {
-	//			typeAttributes.insert(attr.type->toString());
-	//		}
-	//	}
-	//	else if (attr.type->getType() == eEntityAttributeParameterType::eGeneralizedType) {
-	//		auto elementType = attr.type;
+	for (const auto attr : allAttributes) {
+		if (attr.type->getType() == eEntityAttributeParameterType::TypeNamed) {
+			if (schema.hasEntity(attr.type->toString())) {
+				entityAttributes.insert(attr.type->toString());
+			}
+			if (schema.hasType(attr.type->toString())) {
+				typeAttributes.insert(attr.type->toString());
+			}
+		}
+		else if (attr.type->getType() == eEntityAttributeParameterType::eGeneralizedType) {
+			auto elementType = attr.type;
 
-	//		while (elementType->getType() == eEntityAttributeParameterType::eGeneralizedType) {
-	//			elementType = std::static_pointer_cast<EntityAttributeGeneralizedType>(elementType)->elementType;
-	//		}
+			while (elementType->getType() == eEntityAttributeParameterType::eGeneralizedType) {
+				elementType = std::static_pointer_cast<EntityAttributeGeneralizedType>(elementType)->elementType;
+			}
 
-	//		if (schema.hasEntity(elementType->toString())) {
-	//			entityAttributes.insert(elementType->toString());
-	//		}
-	//		if (schema.hasType(elementType->toString())) {
-	//			typeAttributes.insert(elementType->toString());
-	//		}
-	//	}
-	//}
+			if (schema.hasEntity(elementType->toString())) {
+				entityAttributes.insert(elementType->toString());
+			}
+			if (schema.hasType(elementType->toString())) {
+				typeAttributes.insert(elementType->toString());
+			}
+		}
+	}
 
-	//auto self = entityAttributes.find(entity.getName());
-	//while (self != entityAttributes.end()) {
-	//	entityAttributes.erase(self);
-	//	self = entityAttributes.find(entity.getName());
-	//}
+	auto self = entityAttributes.find(entity.getName());
+	while (self != entityAttributes.end()) {
+		entityAttributes.erase(self);
+		self = entityAttributes.find(entity.getName());
+	}
 
-	//// Initialize set of resolved classes.
-	//std::set<std::string> resolvedClasses = {};
+	// Initialize set of resolved classes.
+	std::set<std::string> resolvedClasses = {};
 
-	//for (const auto typeName : typeAttributes) {
-	//	if (schema.isSelectType(typeName)) {
-	//		resolveSelectTypeIncludes(schema, entityAttributes, schema.getTypeByName(typeName), resolvedClasses);
-	//	}
-	//}
+	for (const auto typeName : typeAttributes) {
+		if (schema.isSelectType(typeName)) {
+			resolveSelectTypeIncludes(schema, entityAttributes, schema.getTypeByName(typeName), resolvedClasses);
+		}
+	}
 
-	//for (const auto attributeEntityName : entityAttributes) {
-	//	auto attributeEntity = schema.getEntityByName(attributeEntityName);
-	//	resolveEntityIncludes(schema, attributeEntity, entityAttributes, resolvedClasses);
-	//}
+	for (const auto attributeEntityName : entityAttributes) {
+		auto attributeEntity = schema.getEntityByName(attributeEntityName);
+		resolveEntityIncludes(schema, attributeEntity, entityAttributes, resolvedClasses);
+	}
 
-	//if (!entityAttributes.empty()) {
-	//	for (const auto entityAttribute : entityAttributes) {
-	//		writeInclude(out, entityAttribute + ".h");
-	//	}
-	//	linebreak(out);
-	//}
+	if (!entityAttributes.empty()) {
+		for (const auto entityAttribute : entityAttributes) {
+			writeInclude(out, entityAttribute + ".h");
+		}
+		linebreak(out);
+	}
 
-	//writeInclude(out, "EXPRESS/EXPRESSOptionalImpl.h");
-	//writeInclude(out, "EXPRESS/EXPRESSReferenceImpl.h");
+	writeInclude(out, "EXPRESS/EXPRESSOptionalImpl.h");
+	writeInclude(out, "EXPRESS/EXPRESSReferenceImpl.h");
 	linebreak(out);
 
 	writeBeginNamespace(out, schema);
@@ -4176,8 +4176,8 @@ void GeneratorOIP::generateEntitySourceFileREFACTORED(const Schema & schema, con
 
 	writeEndNamespace(out, schema);
 
-	//writeLine(out, "template class OpenInfraPlatform::EarlyBinding::EXPRESSReference<OpenInfraPlatform::" + schema.getName() + "::" + entity.getName() + ">;");
-	//writeLine(out, "template class OpenInfraPlatform::EarlyBinding::EXPRESSOptional<OpenInfraPlatform::EarlyBinding::EXPRESSReference<OpenInfraPlatform::" + schema.getName() + "::" + entity.getName() + ">" + ">;");
+	writeLine(out, "template class OpenInfraPlatform::EarlyBinding::EXPRESSReference<OpenInfraPlatform::" + schema.getName() + "::" + entity.getName() + ">;");
+	writeLine(out, "template class OpenInfraPlatform::EarlyBinding::EXPRESSOptional<OpenInfraPlatform::EarlyBinding::EXPRESSReference<OpenInfraPlatform::" + schema.getName() + "::" + entity.getName() + ">" + ">;");
 	out.close();
 }
 

--- a/ExpressBindingGenerator/src/Meta/Entity.cpp
+++ b/ExpressBindingGenerator/src/Meta/Entity.cpp
@@ -35,6 +35,14 @@ void Entity::setName(const std::string& value) {
 	name_ = value;
 }
 
+bool Entity::isAbstract() const { 
+	return abstract_;
+}
+
+void Entity::setAbstract( const bool b ) { 
+	abstract_ = b;
+}
+
 size_t Entity::getSubtypeCount() const {
 	return subtypes_.size();
 }

--- a/ExpressBindingGenerator/src/Meta/Entity.h
+++ b/ExpressBindingGenerator/src/Meta/Entity.h
@@ -51,6 +51,14 @@ class Entity {
     void setName(const std::string &value);
 
     //---------------------------------------------------------------
+    // Abstract
+    //---------------------------------------------------------------
+
+    bool isAbstract() const;
+
+    void setAbstract( const bool b );
+
+    //---------------------------------------------------------------
     // Supertypes
     //---------------------------------------------------------------
 
@@ -115,6 +123,7 @@ class Entity {
 
 
   private:
+    bool abstract_;
     std::string parentEntity_;
     std::string name_;
     std::vector<std::string> subtypes_;

--- a/ExpressBindingGenerator/src/Meta/Schema.cpp
+++ b/ExpressBindingGenerator/src/Meta/Schema.cpp
@@ -226,7 +226,7 @@ std::vector<EntityAttribute> Schema::getAllEntityAttributes(const Entity& entity
 
 const bool Schema::isAbstract(const Entity & entity) const
 {
-	return getAllEntityAttributes(entity).size() == 0;
+	return entity.isAbstract();
 }
 
 OIP_NAMESPACE_OPENINFRAPLATFORM_EXPRESSBINDINGGENERATOR_END

--- a/ExpressBindingGenerator/src/Parser/parser.y
+++ b/ExpressBindingGenerator/src/Parser/parser.y
@@ -26,6 +26,7 @@
 	#include <sstream>
 	std::string g_parentName = "";
 	bool g_hasParent = false;
+	bool g_isAbstract = false;
 
 
 	std::stack<int>									integers;
@@ -1165,6 +1166,7 @@ entity_decl:
 		oip::Schema::getInstance().addEntity(currentEntity);
 		currentEntity = Entity();
 		g_hasParent = false;
+        g_isAbstract = false;
 
 		clear(attribute_types);
 	};
@@ -1176,6 +1178,8 @@ entity_head:
 		entity_ids.pop();
 		
 		currentEntity.setName(entityName);
+
+        currentEntity.setAbstract(g_isAbstract);
 	}
   | TOKEN_ENTITY entity_id subsuper TOKEN_SEMICOLON
   	{
@@ -1186,6 +1190,8 @@ entity_head:
 				
 		if(g_hasParent)
 			currentEntity.setParentEntity(g_parentName);
+
+        currentEntity.setAbstract(g_isAbstract);
 	};
 
 entity_id:
@@ -1556,7 +1562,14 @@ type_id:
 
 abstract_supertype_declaration:
 	TOKEN_ABSTRACT TOKEN_SUPERTYPE subtype_constraint
-  | TOKEN_ABSTRACT TOKEN_SUPERTYPE;
+    {
+        g_isAbstract = true;
+    }
+  | TOKEN_ABSTRACT TOKEN_SUPERTYPE
+    {
+        g_isAbstract = true;
+    }
+  ;
 
 subtype_constraint:
 	TOKEN_OF TOKEN_BRACKET_OPEN supertype_expression TOKEN_BRACKET_CLOSE;


### PR DESCRIPTION
Eventually fixes #203 .

Currently does not fix anything - just shuffles some code around. Classes call the corresponding functions of their parent classes (entities). Should consider changing the types as well.

Reading of an IFC file is not working currently. I assume it has to do with the interpretation of references.