### PR TITLE
ExpressContainer now handles Select-like elements

### DIFF
--- a/Core/src/IfcGeometryConverter/CurveConverter.h
+++ b/Core/src/IfcGeometryConverter/CurveConverter.h
@@ -766,7 +766,15 @@ namespace OpenInfraPlatform {
 								carve::geom::vector<3> arcEnd = points[arcIndex[2]];
 
 								//TODO implement IfcArcIndex
-								throw oip::UnhandledException(polycurve);
+								// currently faked - only start-mid-end points are added (very badly tessellated)
+								std::vector<carve::geom::vector<3>> loop_intern;
+								for (const auto& i : arcIndex)
+								{
+									loop_intern.push_back(points[i-1]); //EXPRESS count from 1, C++ from 0
+								}
+
+								// skips same points
+								GeomUtils::appendPointsToCurve(loop_intern, loop);
 
 								break;
 							}
@@ -781,7 +789,7 @@ namespace OpenInfraPlatform {
 								std::vector<carve::geom::vector<3>> loop_intern;
 								for ( const auto& i : lineIndex )
 								{
-									loop_intern.push_back(points[i]);
+									loop_intern.push_back(points[i-1]); //EXPRESS count from 1, C++ from 0
 								}
 
 								// skips same points

--- a/Core/src/IfcGeometryConverter/SolidModelConverter.h
+++ b/Core/src/IfcGeometryConverter/SolidModelConverter.h
@@ -371,17 +371,9 @@ namespace OpenInfraPlatform
 					double radius = swept_disk_solid->Radius * length_in_meter;
 					
 
-					double radius_inner = 0.0;
-					typename IfcEntityTypesT::IfcLengthMeasure& sweptInnerRadius = swept_disk_solid->InnerRadius;
-					if (swept_disk_solid->InnerRadius)
-					{
-						radius_inner = sweptInnerRadius * length_in_meter;
-						//radius_inner = swept_disp_solid->InnerRadius->length_in_meter;
-					}
-
-					double inner_radius = swept_disk_solid->InnerRadius;
-					double start_param = swept_disk_solid->StartParam;
-					double end_param = swept_disk_solid->EndParam;
+					double radius_inner = swept_disk_solid->InnerRadius.value_or(0.0);
+					//double start_param = swept_disk_solid->StartParam.value_or(0.0);
+					//double end_param = swept_disk_solid->EndParam.value_or(1.0);
 
 					// TODO: handle inner radius, start param, end param and check for formal propositions!
 

--- a/EarlyBinding/src/EXPRESS/EXPRESSContainer.h
+++ b/EarlyBinding/src/EXPRESS/EXPRESSContainer.h
@@ -144,20 +144,69 @@ public:
 			//       or																					<   >
 			if (nOpenedParenthesis == 0)
 			{
+				// check if it is a select type - need to account for that
+				// e.g. #491= IFCINDEXEDPOLYCURVE(#545,(IFCLINEINDEX((1,2,3,4,1))),.F.);
+				//    <from - to>                      <                         >
 				// find the first comma that follows
-				auto pos = paramvalue.find_first_of(',', currentpos + 1);
+				auto posEnd = paramvalue.find_first_of(',', currentpos + 1);
+				auto posMid = paramvalue.find_first_of('(', currentpos + 1);
 				// if none found -> take the end
-				if (pos == std::string::npos)
-					pos = paramvalue.size();
+				if (posEnd == std::string::npos)
+					posEnd = paramvalue.size();
+				// if '(' comes before ',' -> we have a case of SelectType
+				if (posMid != std::string::npos && posMid < posEnd)
+				{
+					auto cntr = posMid;
+					int countOpened = 1;
+					bool brk = false;
+					bool ignr = false;
+					while (!brk && ++cntr < paramvalue.size())
+					{
+						if(ignr)
+						{
+							if (paramvalue.at(cntr) == '\'')
+							{
+								ignr = false;
+							}
+
+							continue;
+						}
+
+						switch (paramvalue.at(cntr))
+						{
+						case '\'':
+						{
+							ignr = true;
+							break;
+						}
+						case ')':
+						{
+							if (--countOpened == 0)
+								brk = true;
+							break;
+						}
+						case '(':
+						{
+							countOpened++;
+							break;
+						}
+						}
+					}
+
+					posEnd = paramvalue.find_first_of(',', cntr+1);
+					// if none found -> take the end
+					if (posEnd == std::string::npos)
+						posEnd = paramvalue.size();
+				}
 
 				// Interpret the value
 				ValueType type;
-				std::string sub = paramvalue.substr(start, pos-start);
+				std::string sub = paramvalue.substr(start, posEnd -start);
 				type = ValueType::readStepData(sub, model);
 				result.push_back(type);
 
 				// Continue along the string, skip the sub
-				auto len = pos - currentpos;
+				auto len = posEnd - currentpos;
 				// if we are in the middle of a list, count 1 more to skip the comma
 				if ( it + len != paramvalue.end() )
 					len += 1;


### PR DESCRIPTION
Fixes #177 . Resolves #72 .

Example file `reinforcing assembly` now loads and renders correctly (one needs to zoom in to cut the front plane):

![grafik](https://user-images.githubusercontent.com/59165496/99188057-56b25600-275a-11eb-98d6-28b20ab4709d.png)
