### PR TITLE
Solving 126 and 174 and 400

### DIFF
--- a/Core/src/DataManagement/General/AsyncJob.cpp
+++ b/Core/src/DataManagement/General/AsyncJob.cpp
@@ -39,7 +39,10 @@ bool OpenInfraPlatform::AsyncJob::updateStatus(float progress, const std::string
 void OpenInfraPlatform::AsyncJob::cancelJob()
 {
 	if (running_)
+	{
 		cancel_ = true;
+		err_ = "Canceled";
+	}
 }
 
 void OpenInfraPlatform::AsyncJob::run()
@@ -48,6 +51,13 @@ void OpenInfraPlatform::AsyncJob::run()
 		running_ = true;
 		job_();
 		running_ = false;
+		Q_EMIT finished();
+	}
+	catch (const std::exception& ex) {
+		/*Catch any occurring exceptions and cancel job.*/
+		running_ = false;
+		cancel_ = true;
+		err_ = ex.what();
 		Q_EMIT finished();
 	}
 	catch(...) {

--- a/Core/src/DataManagement/General/AsyncJob.h
+++ b/Core/src/DataManagement/General/AsyncJob.h
@@ -60,6 +60,7 @@ namespace OpenInfraPlatform
 			jobID_++;
 			first_ = true;
 			cancel_ = running_ = false;
+			err_ = "";
 
 			status_ = AsyncStatus();
 
@@ -77,6 +78,8 @@ namespace OpenInfraPlatform
 		bool updateStatus(const std::string& message);
 
 		void cancelJob();
+
+		const std::string errors() const { return err_; }
 
 		/*Signals to communicate job progress/status to the main thread.*/
 		boost::signals2::signal<void()> jobStarting;
@@ -97,6 +100,8 @@ namespace OpenInfraPlatform
 			refreshTimer_ = new QTimer();
 			refreshTimer_->setInterval(200);
 			connect(refreshTimer_, SIGNAL(timeout()), this, SLOT(checkThread()));
+
+			err_ = "";
 		}
 
 		void run();
@@ -114,6 +119,8 @@ namespace OpenInfraPlatform
 		std::mutex statusMutex_;
 		AsyncStatus status_;
 
-		QTimer*	refreshTimer_;
+		QTimer*	refreshTimer_; 
+
+		std::string err_;
 	};
 }

--- a/Core/src/DataManagement/General/Data.cpp
+++ b/Core/src/DataManagement/General/Data.cpp
@@ -245,7 +245,8 @@ void OpenInfraPlatform::Core::DataManagement::Data::jobFinished(int jobID, bool 
 
 	if(!completed) {
 		/*If job was cancelled show message box to inform the user and return.*/
-		showError("Import job cancelled. Error message was written to log file.", "Import Error!");
+		const std::string err = OpenInfraPlatform::AsyncJob::getInstance().errors();
+		showError(QString::fromStdString("Import job cancelled. Error(s):\n" + (err.empty() ? "None" : err)), "Import Error!");
 		return;
 	}
 

--- a/Core/src/IfcGeometryConverter/GeorefConverter.h
+++ b/Core/src/IfcGeometryConverter/GeorefConverter.h
@@ -84,7 +84,7 @@ public:
 
 	oip::GeorefMetadata getGeorefMetadata() const noexcept(false) {
 		if (georefMetadata_.size() < 1)
-			throw std::invalid_argument("No georefencing metadata available");
+			return oip::GeorefMetadata();
 
 		return *(georefMetadata_[0].second);
 	}

--- a/Core/src/IfcGeometryConverter/IfcImporter.h
+++ b/Core/src/IfcGeometryConverter/IfcImporter.h
@@ -92,6 +92,11 @@ public:
 			BLUE_LOG(warning) << "Inconsistent IFC moddelling: " << ex.what();
 			return ifcModel;
 		}
+		catch (const std::invalid_argument& ex)
+		{
+			BLUE_LOG(error) << "Invalid argument exception: " << ex.what();
+			return ifcModel;
+		}
 		catch (...)
 		{
 			BLUE_LOG(warning) << "Something went wrong while collecting data from the IFC file.";

--- a/Core/src/IfcGeometryConverter/PlacementConverter.h
+++ b/Core/src/IfcGeometryConverter/PlacementConverter.h
@@ -1175,11 +1175,8 @@ namespace OpenInfraPlatform {
 						throw oip::ReferenceExpiredException(objectPlacement);
 
 					// Prevent cyclic relative placement
-					// this doesn't work as long as there is no comparisson operator==
-					//if(std::find(alreadyApplied.begin(), alreadyApplied.end(), objectPlacement) != alreadyApplied.end())
-					for (const auto& el : alreadyApplied)
-						if (el->getId() == objectPlacement->getId())
-							throw oip::InconsistentModellingException(objectPlacement, "Cyclic application of IfcObjectPlacement!");
+					if(std::find(alreadyApplied.begin(), alreadyApplied.end(), objectPlacement) != alreadyApplied.end())
+						throw oip::InconsistentModellingException(objectPlacement, "Cyclic application of IfcObjectPlacement!");
 
 					// Add self to apllied
 					alreadyApplied.push_back(objectPlacement);

--- a/EarlyBinding/src/EXPRESS/EXPRESSReference.h
+++ b/EarlyBinding/src/EXPRESS/EXPRESSReference.h
@@ -151,7 +151,8 @@ public:
 			reference.base::operator=(std::dynamic_pointer_cast<T>(model->entities[refId]));
 		}
 		else {
-			throw std::invalid_argument("Could not find reference with ID=" + std::to_string(refId));
+			const std::string err = "Could not find reference with ID=" + std::to_string(refId);
+			throw std::invalid_argument(err);
 		}
 		reference.refId = refId;
 		reference.model = model;

--- a/EarlyBinding/src/EXPRESS/EXPRESSReference.h
+++ b/EarlyBinding/src/EXPRESS/EXPRESSReference.h
@@ -104,9 +104,14 @@ public:
 	const std::string getStepParameter() const override;
 	
 	template <class V>
-	bool operator==(const EXPRESSReference<V>& other) const
+	const bool operator==(const EXPRESSReference<V>& other) const
 	{
 		return this->refId == other.getId();
+	}
+	template <class V>
+	const bool operator!=(const EXPRESSReference<V>& other) const
+	{
+		return !operator==<V>(other);
 	}
 
 	T* operator->() { return this->lock().operator->(); }

--- a/EarlyBinding/src/EXPRESS/EXPRESSReference.h
+++ b/EarlyBinding/src/EXPRESS/EXPRESSReference.h
@@ -152,7 +152,7 @@ public:
 		}
 		else {
 			const std::string err = "Could not find reference with ID=" + std::to_string(refId);
-			throw std::invalid_argument(err);
+			throw std::invalid_argument(err.c_str());
 		}
 		reference.refId = refId;
 		reference.model = model;

--- a/ExpressBindingGenerator/src/Generator/GeneratorOIP.cpp
+++ b/ExpressBindingGenerator/src/Generator/GeneratorOIP.cpp
@@ -2221,7 +2221,7 @@ void GeneratorOIP::generateReaderFiles(const Schema & schema)
 	writeLine(file, "} // end if line[0] == '#'");
 	writeLine(file, "} // end for read file");
 	writeLine(file, "if (errors.size() != 0)	{");
-	writeLine(file, "std::string all = "";");
+	writeLine(file, "std::string all = \"\";");
 	writeLine(file, "std::for_each(errors.begin(), errors.end(), [&all](const std::string& el) {all += el + \"\\n\"; });");
 	writeLine(file, "all.pop_back();");
 	writeLine(file, "throw std::exception(all.c_str());");

--- a/ExpressBindingGenerator/src/Generator/GeneratorOIP.cpp
+++ b/ExpressBindingGenerator/src/Generator/GeneratorOIP.cpp
@@ -2192,7 +2192,7 @@ void GeneratorOIP::generateReaderFiles(const Schema & schema)
 
 	linebreak(file);
 	writeLine(file, "// initialize cross-references");
-	writeLine(file, "td::vector<std::string> errors;");
+	writeLine(file, "std::vector<std::string> errors;");
 	writeLine(file, "#pragma omp parallel for shared(model, lines, errors)");
 	writeLine(file, "for(long i = 0; i < lines.size(); i++) {"); // begin for read file
 	writeLine(file, "auto line = lines[i];");

--- a/ExpressBindingGenerator/src/Generator/GeneratorOIP.cpp
+++ b/ExpressBindingGenerator/src/Generator/GeneratorOIP.cpp
@@ -2192,7 +2192,8 @@ void GeneratorOIP::generateReaderFiles(const Schema & schema)
 
 	linebreak(file);
 	writeLine(file, "// initialize cross-references");
-	writeLine(file, "#pragma omp parallel for shared(model, lines)");
+	writeLine(file, "td::vector<std::string> errors;");
+	writeLine(file, "#pragma omp parallel for shared(model, lines, errors)");
 	writeLine(file, "for(long i = 0; i < lines.size(); i++) {"); // begin for read file
 	writeLine(file, "auto line = lines[i];");
 	writeLine(file, "if(line == \"\") continue;");


### PR DESCRIPTION
fixes #126

- `EXPRESSReference` now has comparison operators (`==` and `!=`)
- useful for `std::find`, for example

resolves #174

- `EXPRESSReference` now throws if a reference cannot be resolved

*EDIT*: resolves #400 

- generator now produces `try-catch` code inside the reader's `for`-loop
- errors gets stored in a vector that gets thrown (concatenated) onwards
- the UI reacts to thrown errors and show them to the user