### PR TITLE
Including schemas in solution

### DIFF
--- a/ExpressBindingGenerator/CMakeLists.txt
+++ b/ExpressBindingGenerator/CMakeLists.txt
@@ -52,30 +52,11 @@ macro(add_format format schema active)
 	set(EARLYBINDING_${format} ${format} ${schema})
 	set(SUPPORTED_IFC_FORMATS ${SUPPORTED_IFC_FORMATS} EARLYBINDING_${format})
 	option(EARLYBINDING_WITH_${format} "Build with support for ${format} and generate all required files." ${active})
-	
-	#if(${active})
-	#	set(IFC_FORMATS ${IFC_FORMATS} ${format})
-	#	set(IFC_SCHEMAS ${IFC_SCHEMAS} ${schema})
-	#	
-	#	# Custom target that generates the early binding library files.
-	#	add_custom_target(Commands.GenerateEarlyBinding.${format}
-	#		COMMAND ${CMAKE_COMMAND} -E make_directory ${CMAKE_BINARY_DIR}/EarlyBinding
-	#		COMMAND ${CMAKE_COMMAND} -E remove_directory  ${CMAKE_BINARY_DIR}/EarlyBinding/${format}
-	#
-	#		COMMAND OpenInfraPlatform.ExpressBindingGenerator ${CMAKE_CURRENT_SOURCE_DIR}/schemas/${schema}.exp -o ${CMAKE_BINARY_DIR}/EarlyBinding
-	#	)
-	#
-	#	add_dependencies(Commands.GenerateEarlyBinding.${format} OpenInfraPlatform.ExpressBindingGenerator)
-	#	set_target_properties(Commands.GenerateEarlyBinding.${format} PROPERTIES FOLDER "OpenInfraPlatform/ExpressBindingGenerator/Commands")
-	#endif()
 endmacro()
 
 add_format(IFC2X3 			IFC2X3_TC1 		OFF)
 add_format(IFC4 			IFC4_ADD1 		OFF)
-add_format(IFC4X2_BIM4ROAD 	IFC4x2_BIM4ROAD	OFF)
 add_format(IFC4X1		 	IFC4x1_RC3		OFF)
-add_format(IFC4X2_DRAFT_1 	IFC4x2_DRAFT_1	OFF)
-add_format(IFC4X2			IFC4x2			OFF)
 add_format(IFC4X3_RC1	 	IFC4X3_RC1		OFF)
 add_format(IFC4X3_RC2	 	IFC4X3_RC2		OFF)
 
@@ -116,7 +97,6 @@ bison_target(Parser
 )
 	
 flex_target(Scanner ${CMAKE_CURRENT_SOURCE_DIR}/src/Parser/tokens.l  ${CMAKE_CURRENT_BINARY_DIR}/lexer.cpp)
-#flex_target(Scanner ${CMAKE_CURRENT_SOURCE_DIR}/ExpressBindingGenerator/Parser/tokens.l  ${CMAKE_CURRENT_BINARY_DIR}/lexer.cpp)
 add_flex_bison_dependency(Scanner Parser)
 
 include_directories(

--- a/ExpressBindingGenerator/CMakeLists.txt
+++ b/ExpressBindingGenerator/CMakeLists.txt
@@ -118,11 +118,19 @@ source_group(ExpressBindingGenerator\\Meta    						FILES ${ExpressBindingGenera
 source_group(ExpressBindingGenerator\\Parser						FILES ${ExpressBindingGenerator_Parser_Source})	
 source_group(ExpressBindingGenerator\\Parser\\Generated				FILES ${FLEX_Scanner_OUTPUTS} ${BISON_Parser_OUTPUTS})	
 
+# add also schema to the solution
+foreach(standard IN LISTS SUPPORTED_IFC_FORMATS)
+	list(GET ${standard} 1 schema)
+	set(ExpressBindingGenerator_Data_Schemas ${ExpressBindingGenerator_Data_Schemas} schemas/${schema}.exp)
+endforeach()
+source_group(Schemas  						FILES ${ExpressBindingGenerator_Data_Schemas})	
+
 add_executable(OpenInfraPlatform.ExpressBindingGenerator
 	${ExpressBindingGenerator_Source}
 	${ExpressBindingGenerator_General_Source}
 	${ExpressBindingGenerator_Generator_Source}
 	${ExpressBindingGenerator_Meta_Source}
+	${ExpressBindingGenerator_Data_Schemas}
 	${ExpressBindingGenerator_Parser_Source}
 	${FLEX_Scanner_OUTPUTS} 
 	${BISON_Parser_OUTPUTS}

--- a/ExpressBindingGenerator/CMakeLists.txt
+++ b/ExpressBindingGenerator/CMakeLists.txt
@@ -41,10 +41,6 @@ if(NOT tclap_POPULATED)
 	FetchContent_Populate(tclap)
 endif()
 
-# Create list of possible IFC formats
-#set(SUPPORTED_IFC_FORMATS IFC2X3 IFC4 IFC4X2_BIM4ROAD IFC4X1 IFC4X2_DRAFT_1 IFC4X2 IFC4X3_ALPHA)
-
-
 
 # Macro to add IFC formats and the respective schemas.
 macro(add_format format schema active)


### PR DESCRIPTION
Simple tweak, so that IFC schemas now also appear in the solution.

Only those schemas currently allowed to be chosen in CMake are added.