### PR TITLE
Screen shot maker

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -161,6 +161,18 @@ endif()
 
 
 FetchContent_Declare(
+	tclap
+	GIT_REPOSITORY https://github.com/mirror/tclap.git
+	GIT_TAG v1.2.2
+)
+  
+FetchContent_GetProperties(tclap)
+if(NOT tclap_POPULATED)
+	FetchContent_Populate(tclap)
+endif()
+
+
+FetchContent_Declare(
 	visit_struct
 	GIT_REPOSITORY https://github.com/cbeck88/visit_struct.git
 	GIT_TAG v1.0

--- a/Core/src/IfcGeometryConverter/IfcImporterImpl.h
+++ b/Core/src/IfcGeometryConverter/IfcImporterImpl.h
@@ -55,7 +55,7 @@ OIP_NAMESPACE_OPENINFRAPLATFORM_CORE_IFCGEOMETRYCONVERTER_BEGIN
 template <
 	class IfcEntityTypesT
 >
-IfcImporterT<IfcEntityTypesT>::IfcImporterT<IfcEntityTypesT>()
+IfcImporterT<IfcEntityTypesT>::IfcImporterT<IfcEntityTypesT>::IfcImporterT()
 {
 	geomSettings = std::make_shared<GeometrySettings>();
 	unitConverter = std::make_shared<UnitConverter<IfcEntityTypesT>>();

--- a/ExpressBindingGenerator/CMakeLists.txt
+++ b/ExpressBindingGenerator/CMakeLists.txt
@@ -29,19 +29,6 @@ find_package(FLEX REQUIRED)
 find_package(BISON REQUIRED)
 
 
-#find_path(TCLAP_INCLUDE_DIR REQUIRED)
-FetchContent_Declare(
-	tclap
-	GIT_REPOSITORY https://github.com/mirror/tclap.git
-	GIT_TAG v1.2.2
-)
-  
-FetchContent_GetProperties(tclap)
-if(NOT tclap_POPULATED)
-	FetchContent_Populate(tclap)
-endif()
-
-
 # Macro to add IFC formats and the respective schemas.
 macro(add_format format schema active)
 	set(${format}_SCHEMA ${schema}.exp)

--- a/UnitTests/Utilities/CMakeLists.txt
+++ b/UnitTests/Utilities/CMakeLists.txt
@@ -16,3 +16,4 @@
 #
 
 add_subdirectory(GeometryModelRenderer)
+add_subdirectory(ScreenShotMaker)

--- a/UnitTests/Utilities/GeometryModelRenderer/CMakeLists.txt
+++ b/UnitTests/Utilities/GeometryModelRenderer/CMakeLists.txt
@@ -15,7 +15,7 @@
 #    along with this program. If not, see <http://www.gnu.org/licenses/>.
 #
 
-project(GeometryModelRenderer)
+project(OpenInfraPlatform.GeometryModelRenderer)
 
 set(CMAKE_AUTOMOC OFF)
 
@@ -23,15 +23,15 @@ file(GLOB OpenInfraPlatform_UnitTests_Utilities_GeometryModelRenderer_Source src
 
 source_group(src FILES ${OpenInfraPlatform_UnitTests_Utilities_GeometryModelRenderer_Source})
 
-add_library(GeometryModelRenderer STATIC ${OpenInfraPlatform_UnitTests_Utilities_GeometryModelRenderer_Source})
+add_library(OpenInfraPlatform.GeometryModelRenderer STATIC ${OpenInfraPlatform_UnitTests_Utilities_GeometryModelRenderer_Source})
 
 
-target_include_directories(GeometryModelRenderer
+target_include_directories(OpenInfraPlatform.GeometryModelRenderer
 	PUBLIC
 		src
 )
 
-target_link_libraries(GeometryModelRenderer
+target_link_libraries(OpenInfraPlatform.GeometryModelRenderer
     PRIVATE
         OpenInfraPlatform.Rendering
         BlueFramework.Engine
@@ -41,4 +41,4 @@ target_link_libraries(GeometryModelRenderer
         Boost::filesystem
 )
 
-set_target_properties(GeometryModelRenderer PROPERTIES FOLDER "OpenInfraPlatform/UnitTests/Utilities")
+set_target_properties(OpenInfraPlatform.GeometryModelRenderer PROPERTIES FOLDER "OpenInfraPlatform/UnitTests/Utilities")

--- a/UnitTests/Utilities/ScreenShotMaker/CMakeLists.txt
+++ b/UnitTests/Utilities/ScreenShotMaker/CMakeLists.txt
@@ -1,0 +1,42 @@
+#
+#    Copyright (c) 2021 Technical University of Munich
+#    Chair of Computational Modeling and Simulation.
+#
+#    TUM Open Infra Platform is free software; you can redistribute it and/or modify
+#    it under the terms of the GNU General Public License Version 3
+#    as published by the Free Software Foundation.
+#
+#    TUM Open Infra Platform is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+#    GNU General Public License for more details.
+#
+#    You should have received a copy of the GNU General Public License
+#    along with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+
+project(OpenInfraPlatform.ScreenShotMaker)
+
+set(CMAKE_AUTOMOC OFF)
+
+file(GLOB OpenInfraPlatform_UnitTests_Utilities_ScreenShotMaker_Source src/*.*)
+
+source_group(src FILES ${OpenInfraPlatform_UnitTests_Utilities_ScreenShotMaker_Source})
+
+add_executable(OpenInfraPlatform.ScreenShotMaker ${OpenInfraPlatform_UnitTests_Utilities_ScreenShotMaker_Source})
+
+
+target_include_directories(OpenInfraPlatform.ScreenShotMaker
+	PUBLIC
+		src
+        ${tclap_SOURCE_DIR}/include
+)
+
+target_link_libraries(OpenInfraPlatform.ScreenShotMaker
+    PRIVATE
+        OpenInfraPlatform.GeometryModelRenderer
+        BlueFramework.Engine
+        Boost::filesystem
+)
+
+set_target_properties(OpenInfraPlatform.ScreenShotMaker PROPERTIES FOLDER "OpenInfraPlatform/UnitTests/Utilities")

--- a/UnitTests/Utilities/ScreenShotMaker/CMakeLists.txt
+++ b/UnitTests/Utilities/ScreenShotMaker/CMakeLists.txt
@@ -25,18 +25,27 @@ source_group(src FILES ${OpenInfraPlatform_UnitTests_Utilities_ScreenShotMaker_S
 
 add_executable(OpenInfraPlatform.ScreenShotMaker ${OpenInfraPlatform_UnitTests_Utilities_ScreenShotMaker_Source})
 
+get_directory_property(PARENT_DIR DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR} PARENT_DIRECTORY)
 
 target_include_directories(OpenInfraPlatform.ScreenShotMaker
 	PUBLIC
 		src
         ${tclap_SOURCE_DIR}/include
+    PRIVATE
+        ${PARENT_DIR}
 )
 
 target_link_libraries(OpenInfraPlatform.ScreenShotMaker
     PRIVATE
         OpenInfraPlatform.GeometryModelRenderer
+        OpenInfraPlatform.Rendering
         BlueFramework.Engine
         Boost::filesystem
 )
+
+foreach(format ${IFC_FORMATS})
+    target_link_libraries(OpenInfraPlatform.ScreenShotMaker PRIVATE OpenInfraPlatform.${format})
+endforeach()
+
 
 set_target_properties(OpenInfraPlatform.ScreenShotMaker PROPERTIES FOLDER "OpenInfraPlatform/UnitTests/Utilities")

--- a/UnitTests/Utilities/ScreenShotMaker/src/main.cpp
+++ b/UnitTests/Utilities/ScreenShotMaker/src/main.cpp
@@ -26,6 +26,8 @@
 #include <string>
 #include <iostream>
 
+#include <boost/filesystem.hpp>
+
 #include "tclap/CmdLine.h"
 
 #include <buw.Engine.h>
@@ -130,12 +132,15 @@ int main(int argc, char **argv) {
 			setUpRenderer<emt::IFC4X3_RC3EntityTypes, OpenInfraPlatform::IFC4X3_RC3::IFC4X3_RC3Reader>(filename);
 #endif
 
+		boost::filesystem::path givenPathToIfcFile(filename);
+		std::string name = givenPathToIfcFile.filename().string();
+
 		renderer->setViewDirection(buw::eViewDirection::Left);
 		buw::Image4b image_left = renderer->captureImage();
-		buw::storeImage(outputDirectoryName + "\\bath-csg-solid_left.png", image_left);
+		buw::storeImage(outputDirectoryName + "\\" + name + "_left.png", image_left);
 
 		std::cout << "Saved image " << std::endl;
-		std::cout << "\\bath-csg-solid_left.png" << std::endl;
+		std::cout << "\\" + name + "_left.png" << std::endl;
 
     } catch (std::exception &ex) {
         std::cout << ex.what() << std::endl;

--- a/UnitTests/Utilities/ScreenShotMaker/src/main.cpp
+++ b/UnitTests/Utilities/ScreenShotMaker/src/main.cpp
@@ -27,12 +27,12 @@
 
 int main(int argc, char **argv) {
     try {
-        TCLAP::CmdLine cmd("oipExpress", ' ', "0.1");
+        TCLAP::CmdLine cmd("oipScreenShot", ' ', "0.1");
 
 		TCLAP::UnlabeledValueArg<std::string> sourceFiles("i", "IFC file.", true, "./rectified", "string");
         cmd.add(sourceFiles);
 
-		TCLAP::ValueArg<std::string> outputDirectory("o", "outputDir", "The output directory for figures.", false, "", "string");
+		TCLAP::ValueArg<std::string> outputDirectory("o", "outputDir", "The output directory for figures.", true, "", "string");
         cmd.add(outputDirectory);
 
         // Parse the args.

--- a/UnitTests/Utilities/ScreenShotMaker/src/main.cpp
+++ b/UnitTests/Utilities/ScreenShotMaker/src/main.cpp
@@ -198,6 +198,8 @@ int main(int argc, char **argv) {
 
     } catch (std::exception &ex) {
         std::cout << ex.what() << std::endl;
+		std::cout << "Press ENTER to exit" << std::endl;
+		getchar();
     }
 
 }

--- a/UnitTests/Utilities/ScreenShotMaker/src/main.cpp
+++ b/UnitTests/Utilities/ScreenShotMaker/src/main.cpp
@@ -238,8 +238,10 @@ int main(int argc, char **argv) {
 		saveAllViews(renderer, outputDirectoryName, filename);
 
     } catch (std::exception &ex) {
+		std::cout << std::endl;
+		std::cout << "---- EXCEPTION ENCOUNTERED ----" << std::endl;
         std::cout << ex.what() << std::endl;
-		std::cout << "Press ENTER to exit" << std::endl;
+		std::cout << "----  Press ENTER to exit  ----" << std::endl;
 		getchar();
     }
 

--- a/UnitTests/Utilities/ScreenShotMaker/src/main.cpp
+++ b/UnitTests/Utilities/ScreenShotMaker/src/main.cpp
@@ -102,13 +102,18 @@ int main(int argc, char **argv) {
         const char* filename = sourceFiles.getValue().c_str();
         std::string outputDirectoryName = outputDirectory.getValue();
 
-		std::cout << "Generating screen shots from " << filename << " to " << outputDirectoryName << std::endl;
-		
+		std::string msg = std::string("Generating screen shots from ");
+		msg += filename;
+		std::cout << msg.c_str() << std::endl;
+		msg = std::string("Saving screen shots to ");
+		msg += outputDirectoryName;
+		std::cout << msg.c_str() << std::endl;
+
         FILE *myfile = fopen(filename, "r");
         // make sure it is valid:
         if (!myfile) {
-			std::cout << "I can't open file " << filename << "!" << std::endl;
-            return -1;
+			std::string err = std::string("I can't open file ") + std::string(filename) + std::string("!");
+			throw std::exception(err.c_str());
         }
 		fclose(myfile);
 
@@ -132,4 +137,6 @@ int main(int argc, char **argv) {
 	// wait for confirm of exit
 	std::cout << "Press any key to exit" << std::endl;
 	getchar();
+
+	return 0;
 }

--- a/UnitTests/Utilities/ScreenShotMaker/src/main.cpp
+++ b/UnitTests/Utilities/ScreenShotMaker/src/main.cpp
@@ -86,6 +86,20 @@ buw::ReferenceCounted<IfcGeometryModelRenderer> setUpRenderer(
 }
 
 
+void saveAllViews(
+	const buw::ReferenceCounted<IfcGeometryModelRenderer>& renderer,
+	const std::string& outputDirectoryName,
+	const std::string& filename
+)
+{
+	renderer->setViewDirection(buw::eViewDirection::Left);
+	buw::Image4b image_left = renderer->captureImage();
+	buw::storeImage(outputDirectoryName + "\\" + filename + "_left.png", image_left);
+
+	std::cout << "Saved image " << std::endl;
+	std::cout << outputDirectoryName + "\\" + filename + "_left.png" << std::endl;
+}
+
 
 int main(int argc, char **argv) {
     try {
@@ -102,18 +116,18 @@ int main(int argc, char **argv) {
 
         // open a file handle to a particular file:
 
-        const char* filename = sourceFiles.getValue().c_str();
+        const char* filepath = sourceFiles.getValue().c_str();
         std::string outputDirectoryName = outputDirectory.getValue();
 
 		std::cout << "Generating screen shots from " << std::endl;
-		std::cout << filename << std::endl;
+		std::cout << filepath << std::endl;
 		std::cout << "Saving screen shots to " << std::endl;
 		std::cout << outputDirectoryName << std::endl;
 
-        FILE *myfile = fopen(filename, "r");
+        FILE *myfile = fopen(filepath, "r");
         // make sure it is valid:
         if (!myfile) {
-			std::string err = std::string("I can't open file ") + std::string(filename) + std::string("!");
+			std::string err = std::string("I can't open file ") + std::string(filepath) + std::string("!");
 			throw std::exception(err.c_str());
         }
 		fclose(myfile);
@@ -121,33 +135,28 @@ int main(int argc, char **argv) {
 
 #ifdef OIP_MODULE_EARLYBINDING_IFC4X1
 		buw::ReferenceCounted<IfcGeometryModelRenderer> renderer = 
-			setUpRenderer<emt::IFC4X1EntityTypes, OpenInfraPlatform::IFC4X1::IFC4X1Reader>(filename);
+			setUpRenderer<emt::IFC4X1EntityTypes, OpenInfraPlatform::IFC4X1::IFC4X1Reader>(filepath);
 #endif
 #ifdef OIP_MODULE_EARLYBINDING_IFC4X3_RC1
 		buw::ReferenceCounted<IfcGeometryModelRenderer> renderer = 
-			setUpRenderer<emt::IFC4X3_RC1EntityTypes, OpenInfraPlatform::IFC4X3_RC1::IFC4X3_RC1Reader>(filename);
+			setUpRenderer<emt::IFC4X3_RC1EntityTypes, OpenInfraPlatform::IFC4X3_RC1::IFC4X3_RC1Reader>(filepath);
 #endif
 #ifdef OIP_MODULE_EARLYBINDING_IFC4X3_RC3
 		buw::ReferenceCounted<IfcGeometryModelRenderer> renderer = 
-			setUpRenderer<emt::IFC4X3_RC3EntityTypes, OpenInfraPlatform::IFC4X3_RC3::IFC4X3_RC3Reader>(filename);
+			setUpRenderer<emt::IFC4X3_RC3EntityTypes, OpenInfraPlatform::IFC4X3_RC3::IFC4X3_RC3Reader>(filepath);
 #endif
 
-		boost::filesystem::path givenPathToIfcFile(filename);
-		std::string name = givenPathToIfcFile.filename().string();
+		boost::filesystem::path givenPathToIfcFile(filepath);
+		std::string filename = givenPathToIfcFile.stem().string();
 
-		renderer->setViewDirection(buw::eViewDirection::Left);
-		buw::Image4b image_left = renderer->captureImage();
-		buw::storeImage(outputDirectoryName + "\\" + name + "_left.png", image_left);
-
-		std::cout << "Saved image " << std::endl;
-		std::cout << "\\" + name + "_left.png" << std::endl;
+		saveAllViews(renderer, outputDirectoryName, filename);
 
     } catch (std::exception &ex) {
         std::cout << ex.what() << std::endl;
     }
 
 	// wait for confirm of exit
-	std::cout << "Press any key to exit" << std::endl;
+	std::cout << "Press ENTER to exit" << std::endl;
 	getchar();
 
 }

--- a/UnitTests/Utilities/ScreenShotMaker/src/main.cpp
+++ b/UnitTests/Utilities/ScreenShotMaker/src/main.cpp
@@ -167,20 +167,18 @@ int main(int argc, char **argv) {
         const char* filepath = sourceFiles.getValue().c_str();
         std::string outputDirectoryName = outputDirectory.getValue();
 
+		// check input
+		boost::filesystem::path givenPathToFile(filepath);
+		if (!boost::filesystem::exists(givenPathToFile))
+			throw std::exception("Provided IFC file does not exist.");
+		if (!boost::filesystem::exists(outputDirectoryName))
+			throw std::exception("Provided output directory does not exist.");
+
 		std::cout << "Generating screen shots from " << std::endl;
 		std::cout << filepath << std::endl;
 		std::cout << "Saving screen shots to " << std::endl;
 		std::cout << outputDirectoryName << std::endl;
 
-        FILE *myfile = fopen(filepath, "r");
-        // make sure it is valid:
-        if (!myfile) {
-			std::string err = std::string("I can't open file ") + std::string(filepath) + std::string("!");
-			throw std::exception(err.c_str());
-        }
-		fclose(myfile);
-
-		boost::filesystem::path givenPathToFile(filepath);
 		std::string filename = givenPathToFile.stem().string();
 		std::string filetype = givenPathToFile.extension().string();
 		std::transform(filetype.begin(), filetype.end(), filetype.begin(), ::tolower);

--- a/UnitTests/Utilities/ScreenShotMaker/src/main.cpp
+++ b/UnitTests/Utilities/ScreenShotMaker/src/main.cpp
@@ -47,6 +47,8 @@ If you wish to debug, you should put the arguments in [Visual Studio]:
 
 #include <string>
 #include <iostream>
+#include <vector>
+#include <utility>
 
 #include <boost/filesystem.hpp>
 
@@ -114,12 +116,33 @@ void saveAllViews(
 	const std::string& filename
 )
 {
-	renderer->setViewDirection(buw::eViewDirection::Left);
-	buw::Image4b image_left = renderer->captureImage();
-	buw::storeImage(outputDirectoryName + "\\" + filename + "_left.png", image_left);
+	std::vector<std::pair< buw::eViewDirection, std::string >> views =
+	{
+		{ buw::eViewDirection::Front, "front"},
+		{ buw::eViewDirection::Top, "top"},
+		{ buw::eViewDirection::Bottom, "bottom"},
+		{ buw::eViewDirection::Left, "left"},
+		{ buw::eViewDirection::Right, "right"},
+		{ buw::eViewDirection::Back, "back"},
+        { buw::eViewDirection::FrontLeftBottom, "front_left_bottom" },
+        { buw::eViewDirection::FrontRightBottom, "front_right_bottom" },
+        { buw::eViewDirection::TopLeftFront, "top_left_front" },
+        { buw::eViewDirection::TopFrontRight, "top_front_right" },
+        { buw::eViewDirection::TopLeftBack, "top_left_back" },
+        { buw::eViewDirection::TopRightBack, "top_right_back" },
+        { buw::eViewDirection::BackLeftBottom, "back_left_bottom" },
+        { buw::eViewDirection::RightBottomBack, "right_bottom_back" }
+	};
 
-	std::cout << "Saved image " << std::endl;
-	std::cout << outputDirectoryName + "\\" + filename + "_left.png" << std::endl;
+	for( const auto& view : views )
+	{
+		renderer->setViewDirection( view.first );
+		buw::Image4b image = renderer->captureImage();
+		buw::storeImage(outputDirectoryName + "\\" + filename + "_" + view.second + ".png", image);
+
+		std::cout << "Saved image " << std::endl;
+		std::cout << outputDirectoryName + "\\" + filename + "_" + view.second + ".png" << std::endl;
+	}
 }
 
 
@@ -176,9 +199,5 @@ int main(int argc, char **argv) {
     } catch (std::exception &ex) {
         std::cout << ex.what() << std::endl;
     }
-
-	// wait for confirm of exit
-	std::cout << "Press ENTER to exit" << std::endl;
-	getchar();
 
 }

--- a/UnitTests/Utilities/ScreenShotMaker/src/main.cpp
+++ b/UnitTests/Utilities/ScreenShotMaker/src/main.cpp
@@ -203,19 +203,36 @@ int main(int argc, char **argv) {
 			std::string msg("File type not IFC, but " + filetype);
 			throw std::exception(msg.c_str());
 		}
-#ifdef OIP_MODULE_EARLYBINDING_IFC4X1
-		buw::ReferenceCounted<IfcGeometryModelRenderer> renderer = 
-			setUpRenderer<emt::IFC4X1EntityTypes, OpenInfraPlatform::IFC4X1::IFC4X1Reader>(filepath);
-#endif
-#ifdef OIP_MODULE_EARLYBINDING_IFC4X3_RC1
-		buw::ReferenceCounted<IfcGeometryModelRenderer> renderer = 
-			setUpRenderer<emt::IFC4X3_RC1EntityTypes, OpenInfraPlatform::IFC4X3_RC1::IFC4X3_RC1Reader>(filepath);
-#endif
-#ifdef OIP_MODULE_EARLYBINDING_IFC4X3_RC3
-		buw::ReferenceCounted<IfcGeometryModelRenderer> renderer = 
-			setUpRenderer<emt::IFC4X3_RC3EntityTypes, OpenInfraPlatform::IFC4X3_RC3::IFC4X3_RC3Reader>(filepath);
-#endif
 
+		buw::ReferenceCounted<IfcGeometryModelRenderer> renderer;
+		if (ifcSchema == IfcPeekStepReader::IfcSchema::IFC4X1) {
+#ifdef OIP_MODULE_EARLYBINDING_IFC4X1
+			renderer =
+				setUpRenderer<emt::IFC4X1EntityTypes, OpenInfraPlatform::IFC4X1::IFC4X1Reader>(filepath);
+#else // OIP_MODULE_EARLYBINDING_IFC4X1
+			throw std::exception("IFC4X1 not compiled");
+#endif //OIP_MODULE_EARLYBINDING_IFC4X1
+		}
+		else if (ifcSchema == IfcPeekStepReader::IfcSchema::IFC4X3_RC1) {
+#ifdef OIP_MODULE_EARLYBINDING_IFC4X3_RC1
+			renderer =
+				setUpRenderer<emt::IFC4X3_RC1EntityTypes, OpenInfraPlatform::IFC4X3_RC1::IFC4X3_RC1Reader>(filepath);
+#else // OIP_MODULE_EARLYBINDING_IFC4X3_RC1
+			throw std::exception("IFC4X3_RC1 not compiled");
+#endif //OIP_MODULE_EARLYBINDING_IFC4X3_RC1
+		}
+		else if (ifcSchema == IfcPeekStepReader::IfcSchema::IFC4X3_RC3) {
+#ifdef OIP_MODULE_EARLYBINDING_IFC4X3_RC3
+			renderer =
+				setUpRenderer<emt::IFC4X3_RC3EntityTypes, OpenInfraPlatform::IFC4X3_RC3::IFC4X3_RC3Reader>(filepath);
+#else // OIP_MODULE_EARLYBINDING_IFC4X3_RC3
+			throw std::exception("IFC4X3_RC3 not compiled");
+#endif //OIP_MODULE_EARLYBINDING_IFC4X3_RC3
+		}
+		else
+		{
+			throw std::exception("IFC version " + strSchema + " not supported");
+		}
 
 		saveAllViews(renderer, outputDirectoryName, filename);
 

--- a/UnitTests/Utilities/ScreenShotMaker/src/main.cpp
+++ b/UnitTests/Utilities/ScreenShotMaker/src/main.cpp
@@ -23,8 +23,18 @@
 #define _CRT_SECURE_NO_WARNINGS
 #endif
 
+#include <string>
+
 #include "tclap/CmdLine.h"
 
+#include <buw.Engine.h>
+#include <buw.ImageProcessing.h>
+
+#include <IfcGeometryConverter/ConverterBuw.h>
+#include <IfcGeometryConverter/IfcImporter.h>
+#include <IfcGeometryConverter/IfcImporterImpl.h>
+
+#include <IfcGeometryModelRenderer.h>
 int main(int argc, char **argv) {
     try {
         TCLAP::CmdLine cmd("oipScreenShot", ' ', "0.1");

--- a/UnitTests/Utilities/ScreenShotMaker/src/main.cpp
+++ b/UnitTests/Utilities/ScreenShotMaker/src/main.cpp
@@ -103,12 +103,10 @@ int main(int argc, char **argv) {
         const char* filename = sourceFiles.getValue().c_str();
         std::string outputDirectoryName = outputDirectory.getValue();
 
-		std::string msg = std::string("Generating screen shots from ");
-		msg += filename;
-		std::cout << msg << std::endl;
-		msg = std::string("Saving screen shots to ");
-		msg += outputDirectoryName;
-		std::cout << msg << std::endl;
+		std::cout << "Generating screen shots from " << std::endl;
+		std::cout << filename << std::endl;
+		std::cout << "Saving screen shots to " << std::endl;
+		std::cout << outputDirectoryName << std::endl;
 
         FILE *myfile = fopen(filename, "r");
         // make sure it is valid:
@@ -136,10 +134,8 @@ int main(int argc, char **argv) {
 		buw::Image4b image_left = renderer->captureImage();
 		buw::storeImage(outputDirectoryName + "\\bath-csg-solid_left.png", image_left);
 
-		msg = std::string("Saved an image to ");
-		msg += outputDirectoryName;
-		msg += std::string("\\bath-csg-solid_left.png");
-		std::cout << msg << std::endl;
+		std::cout << "Saved image " << std::endl;
+		std::cout << "\\bath-csg-solid_left.png" << std::endl;
 
     } catch (std::exception &ex) {
         std::cout << ex.what() << std::endl;

--- a/UnitTests/Utilities/ScreenShotMaker/src/main.cpp
+++ b/UnitTests/Utilities/ScreenShotMaker/src/main.cpp
@@ -189,14 +189,7 @@ int main(int argc, char **argv) {
 		std::string strSchema;
 		if (filetype == ".ifc" || filetype == ".stp")
 		{
-			try
-			{
-				std::tie(strSchema, ifcSchema) = IfcPeekStepReader::parseIfcHeader(filename);
-			}
-			catch (std::exception& ex)
-			{
-				throw;
-			}
+			std::tie(strSchema, ifcSchema) = IfcPeekStepReader::parseIfcHeader(filepath);
 		}
 		else
 		{

--- a/UnitTests/Utilities/ScreenShotMaker/src/main.cpp
+++ b/UnitTests/Utilities/ScreenShotMaker/src/main.cpp
@@ -231,7 +231,8 @@ int main(int argc, char **argv) {
 		}
 		else
 		{
-			throw std::exception("IFC version " + strSchema + " not supported");
+			std::string msg("IFC version " + strSchema + " not supported");
+			throw std::exception(msg.c_str());
 		}
 
 		saveAllViews(renderer, outputDirectoryName, filename);

--- a/UnitTests/Utilities/ScreenShotMaker/src/main.cpp
+++ b/UnitTests/Utilities/ScreenShotMaker/src/main.cpp
@@ -128,7 +128,14 @@ int main(int argc, char **argv) {
 		auto renderer = setUpRenderer<emt::IFC4X3_RC3EntityTypes, OpenInfraPlatform::IFC4X3_RC3::IFC4X3_RC3Reader>(filename);
 #endif
 
+		renderer->setViewDirection(buw::eViewDirection::Left);
+		buw::Image4b image_left = renderer->captureImage();
+		buw::storeImage(outputDirectoryName + "\\bath-csg-solid_left.png", image_left);
 
+		msg = std::string("Saved an image to ");
+		msg += outputDirectoryName;
+		msg += std::string("\\bath-csg-solid_left.png");
+		std::cout << msg << std::endl;
 
     } catch (std::exception &ex) {
         std::cout << ex.what() << std::endl;

--- a/UnitTests/Utilities/ScreenShotMaker/src/main.cpp
+++ b/UnitTests/Utilities/ScreenShotMaker/src/main.cpp
@@ -1,0 +1,67 @@
+/*
+    This file is part of TUM Open Infra Platform Early Binding EXPRESS
+    Generator, a simple early binding generator for EXPRESS.
+    Copyright (c) 2021 Technical University of Munich
+    Chair of Computational Modeling and Simulation.
+
+    TUM Open Infra Platform Early Binding EXPRESS Generator is free
+    software; you can redistribute it and/or modify it under the terms
+    of the GNU General Public License Version 3 as published by the Free
+    Software Foundation.
+
+    TUM Open Infra Platform Early Binding EXPRESS Generator is
+    distributed in the hope that it will be useful, but WITHOUT ANY
+    WARRANTY; without even the implied warranty of MERCHANTABILITY or
+    FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+    for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program. If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifdef _MSC_VER
+#define _CRT_SECURE_NO_WARNINGS
+#endif
+
+#include "tclap/CmdLine.h"
+
+int main(int argc, char **argv) {
+    try {
+        TCLAP::CmdLine cmd("oipExpress", ' ', "0.1");
+
+		TCLAP::UnlabeledValueArg<std::string> sourceFiles("i", "IFC file.", true, "./rectified", "string");
+        cmd.add(sourceFiles);
+
+		TCLAP::ValueArg<std::string> outputDirectory("o", "outputDir", "The output directory for figures.", false, "", "string");
+        cmd.add(outputDirectory);
+
+        // Parse the args.
+        cmd.parse(argc, argv);
+
+        // open a file handle to a particular file:
+
+        const char* filename = sourceFiles.getValue().c_str();
+        std::string outputDirectoryName = outputDirectory.getValue();
+
+		std::cout << "Generating screen shots from " << filename << " to " << outputDirectoryName << std::endl;
+		
+        FILE *myfile = fopen(filename, "r");
+        // make sure it is valid:
+        if (!myfile) {
+			std::cout << "I can't open file " << filename << "!" << std::endl;
+            return -1;
+        }
+		fclose(myfile);
+
+
+
+
+
+    } catch (std::exception &ex) {
+        std::cout << ex.what() << std::endl;
+    }
+
+	// wait for confirm of exit
+	std::cout << "Press any key to exit" << std::endl;
+	getchar();
+}

--- a/UnitTests/Utilities/ScreenShotMaker/src/main.cpp
+++ b/UnitTests/Utilities/ScreenShotMaker/src/main.cpp
@@ -19,6 +19,28 @@
     along with this program. If not, see <http://www.gnu.org/licenses/>.
 */
 
+/* INSTRUCTIONS 
+
+Usage:
+
+> OpenInfraPlatform.ScreenShotMaker.exe <pathToIfcFile> -o <pathToOutputDirectory>
+
+with:
+
+- <pathToIfcFile>: the relative or absolute path to the IFC file to be rendered
+- <pathToOutputDirectory>: the relative or absolute path to the directory where screen shots should be saved
+
+*NOTE:* make sure that the correct IFC version is being compiled - select accordingly in CMake.
+
+If you wish to debug, you should put the arguments in [Visual Studio]:
+- OpenInfraPlatform.ScreenShotMaker project -> right mouse button
+- Properties
+- Debuggin
+- Command Arguments
+
+*/
+
+
 #ifdef _MSC_VER
 #define _CRT_SECURE_NO_WARNINGS
 #endif

--- a/UnitTests/Utilities/ScreenShotMaker/src/main.cpp
+++ b/UnitTests/Utilities/ScreenShotMaker/src/main.cpp
@@ -24,6 +24,7 @@
 #endif
 
 #include <string>
+#include <iostream>
 
 #include "tclap/CmdLine.h"
 
@@ -104,10 +105,10 @@ int main(int argc, char **argv) {
 
 		std::string msg = std::string("Generating screen shots from ");
 		msg += filename;
-		std::cout << msg.c_str() << std::endl;
+		std::cout << msg << std::endl;
 		msg = std::string("Saving screen shots to ");
 		msg += outputDirectoryName;
-		std::cout << msg.c_str() << std::endl;
+		std::cout << msg << std::endl;
 
         FILE *myfile = fopen(filename, "r");
         // make sure it is valid:
@@ -119,13 +120,16 @@ int main(int argc, char **argv) {
 
 
 #ifdef OIP_MODULE_EARLYBINDING_IFC4X1
-		auto renderer = setUpRenderer<emt::IFC4X1EntityTypes, OpenInfraPlatform::IFC4X1::IFC4X1Reader>(filename);
+		buw::ReferenceCounted<IfcGeometryModelRenderer> renderer = 
+			setUpRenderer<emt::IFC4X1EntityTypes, OpenInfraPlatform::IFC4X1::IFC4X1Reader>(filename);
 #endif
 #ifdef OIP_MODULE_EARLYBINDING_IFC4X3_RC1
-		auto renderer = setUpRenderer<emt::IFC4X3_RC1EntityTypes, OpenInfraPlatform::IFC4X3_RC1::IFC4X3_RC1Reader>(filename);
+		buw::ReferenceCounted<IfcGeometryModelRenderer> renderer = 
+			setUpRenderer<emt::IFC4X3_RC1EntityTypes, OpenInfraPlatform::IFC4X3_RC1::IFC4X3_RC1Reader>(filename);
 #endif
 #ifdef OIP_MODULE_EARLYBINDING_IFC4X3_RC3
-		auto renderer = setUpRenderer<emt::IFC4X3_RC3EntityTypes, OpenInfraPlatform::IFC4X3_RC3::IFC4X3_RC3Reader>(filename);
+		buw::ReferenceCounted<IfcGeometryModelRenderer> renderer = 
+			setUpRenderer<emt::IFC4X3_RC3EntityTypes, OpenInfraPlatform::IFC4X3_RC3::IFC4X3_RC3Reader>(filename);
 #endif
 
 		renderer->setViewDirection(buw::eViewDirection::Left);
@@ -145,5 +149,4 @@ int main(int argc, char **argv) {
 	std::cout << "Press any key to exit" << std::endl;
 	getchar();
 
-	return 0;
 }

--- a/cmake/CreateUnitTests.cmake
+++ b/cmake/CreateUnitTests.cmake
@@ -48,7 +48,7 @@ function(CreateIfcFileVisualUnitTestForSchema test_name schema)
         PUBLIC
             OpenInfraPlatform.${schema}
             OpenInfraPlatform.Rendering
-            GeometryModelRenderer
+            OpenInfraPlatform.GeometryModelRenderer
             BlueFramework.Engine
             gmock
             gtest
@@ -98,7 +98,7 @@ function(CreateOffFileVisualUnitTest test_name)
     target_link_libraries(${UnitTest_Executable_Name}
         PUBLIC
             OpenInfraPlatform.Rendering 
-            GeometryModelRenderer
+            OpenInfraPlatform.GeometryModelRenderer
             BlueFramework.Engine
             gmock
             gtest


### PR DESCRIPTION
Made a small console application that saves all screen shots needed for unit testing.

Usage:

> `OpenInfraPlatform.ScreenShotMaker.exe <pathToIfcFile> -o <pathToOutputDirectory>`

with:

- `<pathToIfcFile>`: the relative or absolute path to the IFC file to be rendered
- `<pathToOutputDirectory>`: the relative or absolute path to the directory where screen shots should be saved

*NOTE:* make sure that the correct IFC version is being compiled - select accordingly in CMake.

