### PR TITLE
corrected getStepLine to account for qualified attributes

### DIFF
--- a/ExpressBindingGenerator/src/Generator/GeneratorOIP.cpp
+++ b/ExpressBindingGenerator/src/Generator/GeneratorOIP.cpp
@@ -3138,9 +3138,15 @@ void GeneratorOIP::generateEntitySourceFileREFACTORED(const Schema & schema, con
 		writeLine(out, "boost::to_upper(classname);");
 		writeLine(out, "std::string stepLine = this->getStepParameter() + \"=\" + classname + \"(\";");
 		for (int i = 0; i < attributes.size() - 1; i++) {
-			writeLine(out, "stepLine += " + attributes[i].getName() + ".getStepParameter() + \",\";");
+			if( entity.hasQualifiedAttribute(attributes[i].getName()) )
+				writeLine(out, "stepLine += \"*,\"; // " + attributes[i].getName() + " is a qualified attribute of " + name);
+			else
+				writeLine(out, "stepLine += " + attributes[i].getName() + ".getStepParameter() + \",\";");
 		}
-		writeLine(out, "stepLine += " + attributes.back().getName() + ".getStepParameter() + \");\";");
+		if( entity.hasQualifiedAttribute(attributes.back().getName() ) )
+			writeLine(out, "stepLine += \"*);\"; // " + attributes.back().getName() + " is a qualified attribute of " + name);
+		else
+			writeLine(out, "stepLine += " + attributes.back().getName() + ".getStepParameter() + \");\";");
 		writeLine(out, "return stepLine;");
 		writeLine(out, "}");
 		linebreak(out);


### PR DESCRIPTION
Fixes #456

`getStepLine` of e.g. `IfcSIUnit` should now correctly return `*` for its first attribute in STEP serialization:

```
		/*!
		 * \brief Returns the STEP serialization.
		 * 
		 * \return #ID=IfcSIUnit(<attributes>);
		 */
		const std::string IfcSIUnit::getStepLine() const {
			std::string classname = this->classname();
			boost::to_upper(classname);
			std::string stepLine = this->getStepParameter() + "=" + classname + "(";
			stepLine += "*,"; // Dimensions is a qualified attribute of IfcSIUnit
			stepLine += UnitType.getStepParameter() + ",";
			stepLine += Prefix.getStepParameter() + ",";
			stepLine += Name.getStepParameter() + ");";
			return stepLine;
		}
```
