### PR TITLE
Ignoring commented lines for OFF Files

### DIFF
--- a/Core/src/OffConverter/OffReader.cpp
+++ b/Core/src/OffConverter/OffReader.cpp
@@ -52,11 +52,7 @@ std::shared_ptr<OffModel> OffReader::readFile(const std::string& filename)
 		while (std::getline(offFile, line) && line != "OFF");
 
 		//read number of elements
-		//getline(offFile, line);
-		if (!OffReader::getNextUncommentedLine(offFile, line))
-		{
-			return false;
-		}
+		line = OffReader::getNextUncommentedLine(offFile, line);
 		std::vector<int>	lineData;
 		std::stringstream	lineStream(line);
 
@@ -85,11 +81,7 @@ std::shared_ptr<OffModel> OffReader::readFile(const std::string& filename)
 		for (int i = 0; i < nrOfFaces; i++)
 		{
 			//which type of face (triangle, quad, ...)
-			if (!OffReader::getNextUncommentedLine(offFile, line))
-			{
-				return false;
-			}
-			//std::getline(offFile, line);
+			line = OffReader::getNextUncommentedLine(offFile, line);
 			std::vector<uint32_t> faceVector;
 			std::stringstream lineStream(line);
 
@@ -138,11 +130,7 @@ std::vector<buw::Vector3f> OffReader::readVertices(const int nrOfVertices,
 	std::vector<buw::Vector3f> allVertices;
 	for (int i = 0; i < nrOfVertices; i++)
 	{
-		//std::getline(offFile, line);
-		if (OffReader::getNextUncommentedLine(offFile, line))
-		{
-			line;
-		}
+		line = OffReader::getNextUncommentedLine(offFile, line);
 		buw::Vector3f position;
 		std::stringstream lineStream(line);
 
@@ -253,16 +241,16 @@ buw::Vector3f OffReader::calcNormal(const buw::Vector3f& vertex1,
 	return buw::Vector3f(normal.x, normal.y, normal.z);
 }
 
-bool OffReader::getNextUncommentedLine(std::ifstream& offFile, std::string& line)
+std::string OffReader::getNextUncommentedLine(std::ifstream& offFile, std::string& line)
 {
 	while (std::getline(offFile, line))
 	{
 		if (line[0] != '#')
 		{
-			return true;
+			return line;
 		}
-	}		
-	return false;
+	}
+	throw oip::OffReaderException("Error in Off file.");
 }
 
 OIP_NAMESPACE_OPENINFRAPLATFORM_CORE_OFFCONVERTER_END

--- a/Core/src/OffConverter/OffReader.cpp
+++ b/Core/src/OffConverter/OffReader.cpp
@@ -257,11 +257,15 @@ bool OffReader::getNextUncommentedLine(std::ifstream& offFile, std::string& line
 {
 	while (std::getline(offFile, line))
 	{
-		if (line[0] != '#')
+		for (int i = 0; i < line.size(); i++)
 		{
-			return true;
+			if (line[i] != '#')
+			{
+				return true;
+			}
 		}
 	}
+		
 	return false;
 }
 

--- a/Core/src/OffConverter/OffReader.cpp
+++ b/Core/src/OffConverter/OffReader.cpp
@@ -257,15 +257,11 @@ bool OffReader::getNextUncommentedLine(std::ifstream& offFile, std::string& line
 {
 	while (std::getline(offFile, line))
 	{
-		for (int i = 0; i < line.size(); i++)
+		if (line[0] != '#')
 		{
-			if (line[i] != '#')
-			{
-				return true;
-			}
+			return true;
 		}
-	}
-		
+	}		
 	return false;
 }
 

--- a/Core/src/OffConverter/OffReader.cpp
+++ b/Core/src/OffConverter/OffReader.cpp
@@ -52,7 +52,11 @@ std::shared_ptr<OffModel> OffReader::readFile(const std::string& filename)
 		while (std::getline(offFile, line) && line != "OFF");
 
 		//read number of elements
-		getline(offFile, line);
+		//getline(offFile, line);
+		if (!OffReader::getNextUncommentedLine(offFile, line))
+		{
+			return false;
+		}
 		std::vector<int>	lineData;
 		std::stringstream	lineStream(line);
 
@@ -81,7 +85,11 @@ std::shared_ptr<OffModel> OffReader::readFile(const std::string& filename)
 		for (int i = 0; i < nrOfFaces; i++)
 		{
 			//which type of face (triangle, quad, ...)
-			std::getline(offFile, line);
+			if (!OffReader::getNextUncommentedLine(offFile, line))
+			{
+				return false;
+			}
+			//std::getline(offFile, line);
 			std::vector<uint32_t> faceVector;
 			std::stringstream lineStream(line);
 
@@ -130,7 +138,11 @@ std::vector<buw::Vector3f> OffReader::readVertices(const int nrOfVertices,
 	std::vector<buw::Vector3f> allVertices;
 	for (int i = 0; i < nrOfVertices; i++)
 	{
-		std::getline(offFile, line);
+		//std::getline(offFile, line);
+		if (OffReader::getNextUncommentedLine(offFile, line))
+		{
+			line;
+		}
 		buw::Vector3f position;
 		std::stringstream lineStream(line);
 
@@ -241,5 +253,16 @@ buw::Vector3f OffReader::calcNormal(const buw::Vector3f& vertex1,
 	return buw::Vector3f(normal.x, normal.y, normal.z);
 }
 
+bool OffReader::getNextUncommentedLine(std::ifstream& offFile, std::string& line)
+{
+	while (std::getline(offFile, line))
+	{
+		if (line[0] != '#')
+		{
+			return true;
+		}
+	}
+	return false;
+}
 
 OIP_NAMESPACE_OPENINFRAPLATFORM_CORE_OFFCONVERTER_END

--- a/Core/src/OffConverter/OffReader.h
+++ b/Core/src/OffConverter/OffReader.h
@@ -116,9 +116,9 @@ public:
 	*
 	* \param[in] offFile The .off file all the information is red from.
 	* \param[in] line The line obtained from file reading (getline).
-	* \return true if the line uncontanes comment or false if the line contanes comment
+	* \return next uncommented line
 	*/
-	static bool getNextUncommentedLine(std::ifstream& offFile, std::string& line);
+	static std::string getNextUncommentedLine(std::ifstream& offFile, std::string& line);
 };
 OIP_NAMESPACE_OPENINFRAPLATFORM_CORE_OFFCONVERTER_END
 

--- a/Core/src/OffConverter/OffReader.h
+++ b/Core/src/OffConverter/OffReader.h
@@ -108,6 +108,17 @@ public:
 	static buw::Vector3f calcNormal(const buw::Vector3f& vertex1,
 		const buw::Vector3f& vertex2,
 		const buw::Vector3f& vertex3);
+
+	/**
+	* \brief get next uncommented line
+	*
+	* This function reads trougt the next line that uncommented.
+	*
+	* \param[in] offFile The .off file all the information is red from.
+	* \param[in] line The line obtained from file reading (getline).
+	* \return true if the line uncontanes comment or false if the line contanes comment
+	*/
+	static bool getNextUncommentedLine(std::ifstream& offFile, std::string& line);
 };
 OIP_NAMESPACE_OPENINFRAPLATFORM_CORE_OFFCONVERTER_END
 


### PR DESCRIPTION
Added new function `getNextUncommentedLine` to read only uncommented lines for OFF files

Fixes #382